### PR TITLE
Issue #122 Implement DialogChoice CustomState

### DIFF
--- a/bak/dialogChoice.cpp
+++ b/bak/dialogChoice.cpp
@@ -32,7 +32,7 @@ std::string_view ToString(ChoiceMask m)
     case ChoiceMask::ItemOrChest: return "ItemOrChest";
     case ChoiceMask::EventFlag: return "EventFlag";
     case ChoiceMask::GameState: return "GameState";
-    case ChoiceMask::StatusOrItem: return "StatusOrItem";
+    case ChoiceMask::CustomState: return "CustomState";
     case ChoiceMask::Inventory: return "Inventory";
     case ChoiceMask::HaveNote: return "HaveNote";
     case ChoiceMask::CastSpell: return "CastSpell";
@@ -73,6 +73,23 @@ std::ostream& operator<<(std::ostream& os, const GameStateChoice& c)
 {
     os << ToString(ChoiceMask::GameState) << " " << ToString(c.mState) 
         << " " << std::hex << c.mExpectedValue << " | " << c.mExpectedValue2;
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, Scenario s)
+{
+    switch (s)
+    {
+        case Scenario::Plagued: os << "Plagued"; break;
+        default: os << "Unknown(" << static_cast<unsigned>(s) << ")";
+    }
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const CustomStateChoice& c)
+{
+    os << ToString(ChoiceMask::CustomState) << " scenario: " << c.mScenario
+        << " flag: " << c.mFlag;
     return os;
 }
 
@@ -131,7 +148,7 @@ ChoiceMask CategoriseChoice(std::uint16_t state)
         ChoiceMask::ItemOrChest,
         ChoiceMask::EventFlag,
         ChoiceMask::GameState,
-        ChoiceMask::StatusOrItem,
+        ChoiceMask::CustomState,
         ChoiceMask::Inventory,
         ChoiceMask::HaveNote,
         ChoiceMask::CastSpell,
@@ -173,6 +190,10 @@ Choice CreateChoice(
             static_cast<ActiveStateFlag>(state),
             choice0,
             choice1};
+    case ChoiceMask::CustomState:
+        return CustomStateChoice{
+            static_cast<Scenario>(state & ~0x9c40),
+            bool(choice0)};
     case ChoiceMask::Inventory:
         return InventoryChoice{
             // This is the math to get the item index

--- a/bak/dialogChoice.hpp
+++ b/bak/dialogChoice.hpp
@@ -52,7 +52,7 @@ enum class ChoiceMask : std::uint16_t
     // These seem to be complex active checks,
     // e.g. check whether character is starving,
     // or check whether there are six suits of armor
-    StatusOrItem = 0x9cff,
+    CustomState = 0x9cff,
     // item that you need is: (c3xx & 0xff) - 0x50
     Inventory = 0xc3ff,
     HaveNote      = 0xc7ff,
@@ -92,6 +92,17 @@ struct GameStateChoice
     std::uint16_t mExpectedValue2;
 };
 
+enum class Scenario : std::uint8_t
+{
+    Plagued = 2
+};
+
+struct CustomStateChoice
+{
+    Scenario mScenario;
+    bool mFlag;
+};
+
 struct InventoryChoice
 {
     ItemIndex mRequiredItem;
@@ -125,6 +136,7 @@ using Choice = std::variant<
     QueryChoice,
     EventFlagChoice,
     GameStateChoice,
+    CustomStateChoice,
     InventoryChoice,
     ComplexEventChoice,
     UnknownChoice>;

--- a/bak/gameState.hpp
+++ b/bak/gameState.hpp
@@ -547,6 +547,16 @@ public:
             [&](const GameStateChoice& c){
                 return EvaluateGameStateChoice(c);
             },
+            [&](const CustomStateChoice& c)
+            {
+                switch (c.mScenario)
+                {
+                case Scenario::Plagued:
+                    return CheckCustomStateScenarioPlagued();
+                default:
+                    return false;
+                }
+            },
             [&](const auto& c){
                 return false; 
             },
@@ -677,8 +687,6 @@ public:
             mGameData->SetPostEnableOrDisableEventFlags(encounter, mZone);
     }
 
-
-
     void SetDialogContext(unsigned contextValue)
     {
         mContextValue = contextValue;
@@ -728,6 +736,21 @@ public:
     {
         ASSERT(zone.mValue < 13);
         return mContainers[zone.mValue - 1];
+    }
+
+    bool CheckCustomStateScenarioPlagued() const
+    {
+        for (auto activeCharIndex = ActiveCharIndex{0};
+            activeCharIndex.mValue < GetParty().GetNumCharacters();
+            activeCharIndex = GetParty().NextActiveCharacter(activeCharIndex))
+        {
+            if (GetParty().GetCharacter(activeCharIndex).GetConditions().GetCondition(BAK::Condition::Plagued).Get() > 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     std::optional<CharIndex> mDialogCharacter;


### PR DESCRIPTION
These are bespoke checks in dialog state, e.g. are any characters plagued, does the party have 6 Kingdom Armor, etc.

I have begun by implementing the first, plagued, used by the dialog with Michelle.