### PR TITLE
Issue #4 Render 3d lines

### DIFF
--- a/app/display_object.cpp
+++ b/app/display_object.cpp
@@ -28,7 +28,7 @@ int main(int argc, char** argv)
     Logging::LogState::Disable("CreateFileBuffer");
     Logging::LogState::Disable("LoadFixedObjects");
     Logging::LogState::Disable("MeshObjectStore");
-    Logging::LogState::Disable("ZoneItemToMeshObject");
+    //Logging::LogState::Disable("ZoneItemToMeshObject");
     Logging::LogState::Disable("World");
     Logging::LogState::Disable("LoadEncounter");
     Logging::LogState::Disable("ZoneFactory");

--- a/app/main3d.cpp
+++ b/app/main3d.cpp
@@ -104,7 +104,7 @@ int main(int argc, char** argv)
 		saveName = "NEW_GAME.GAM";
 	}
 
-    auto guiScalar = 2.0f;
+    auto guiScalar = 4.0f;
 
     auto nativeWidth = 320.0f;
     auto nativeHeight = 200.0f;

--- a/bak/worldFactory.cpp
+++ b/bak/worldFactory.cpp
@@ -124,12 +124,61 @@ Graphics::MeshObject ZoneItemToMeshObject(
     unsigned index = 0;
     for (const auto& face : item.GetFaces())
     {
-        if (face.size() < 3)
+        if (face.size() < 3) // line
         {
-            logger.Debug() << "Face with < 3 vertices: " << index
-                << " - " << item.GetName() << std::endl;
+            auto start = glmVertices[face[0]];
+            auto end = glmVertices[face[1]];
+            auto normal = glm::normalize(
+                glm::cross(end - start, glm::vec3(0, 0, 1.0)));
+            float linewidth = 0.05f;
+            indices.emplace_back(vertices.size());
+            vertices.emplace_back(start + linewidth * normal);
+            indices.emplace_back(vertices.size());
+            vertices.emplace_back(end + linewidth * normal);
+            indices.emplace_back(vertices.size());
+            vertices.emplace_back(start - linewidth * normal);
+
+            indices.emplace_back(vertices.size());
+            vertices.emplace_back(end + linewidth * normal);
+            indices.emplace_back(vertices.size());
+            vertices.emplace_back(start - linewidth * normal);
+            indices.emplace_back(vertices.size());
+            vertices.emplace_back(end - linewidth * normal);
+
+            normals.emplace_back(normal);
+            normals.emplace_back(normal);
+            normals.emplace_back(normal);
+            normals.emplace_back(normal);
+            normals.emplace_back(normal);
+            normals.emplace_back(normal);
+
+            auto colorIndex = item.GetColors().at(index);
+            auto paletteIndex = item.GetPalettes().at(index);
+            auto textureIndex = colorIndex;
+
+            auto color = pal.GetColor(colorIndex);
+            colors.emplace_back(color);
+            colors.emplace_back(color);
+            colors.emplace_back(color);
+
+            colors.emplace_back(color);
+            colors.emplace_back(color);
+            colors.emplace_back(color);
+
+            textureCoords.emplace_back(0.0, 0.0, textureIndex);
+            textureCoords.emplace_back(0.0, 0.0, textureIndex);
+            textureCoords.emplace_back(0.0, 0.0, textureIndex);
+            textureCoords.emplace_back(0.0, 0.0, textureIndex);
+            textureCoords.emplace_back(0.0, 0.0, textureIndex);
+            textureCoords.emplace_back(0.0, 0.0, textureIndex);
+
+            TextureBlend(0.0);
+            TextureBlend(0.0);
+
+            index++;
             continue;
         }
+
         unsigned triangles = face.size() - 2;
 
         // Whether to push this face away from the main plane
@@ -354,6 +403,11 @@ Graphics::MeshObject ZoneItemToMeshObject(
         index++;
     }
 
+    assert(vertices.size() == normals.size());
+    assert(vertices.size() == colors.size());
+    assert(vertices.size() == textureCoords.size());
+    assert(vertices.size() == textureBlends.size());
+    assert(vertices.size() == indices.size());
     return Graphics::MeshObject{
         vertices,
         normals,

--- a/bak/worldFactory.hpp
+++ b/bak/worldFactory.hpp
@@ -124,44 +124,50 @@ public:
                 for (const auto& mesh : component.mMeshes)
                 {
                     assert(mesh.mFaceOptions.size() > 0);
+                    // Only show the first face option. These typically correspond to 
+                    // animation states, e.g. for the door, or catapult, or rift gate.
+                    // Will need to work out how to handle animated things later...
                     const auto& faceOption = mesh.mFaceOptions[0];
-                    for (const auto& face : faceOption.mFaces)
+                    //for (const auto& faceOption : mesh.mFaceOptions)
                     {
-                        mFaces.emplace_back(face);
-                    }
-                    for (const auto& palette : faceOption.mPalettes)
-                    {
-                        mPalettes.emplace_back(palette);
-                    }
-                    for (const auto& colorVec : faceOption.mFaceColors)
-                    {
-                        const auto color = colorVec.x;
-                        mColors.emplace_back(color);
-                        if ((GetName().substr(0, 5) == "house"
-                            || GetName().substr(0, 3) == "inn")
-                            && (color == 190
-                            || color == 191))
-                            mPush.emplace_back(false);
-                        else if (GetName().substr(0, 4) == "blck"
-                            && (color == 145
-                            || color == 191))
-                            mPush.emplace_back(false);
-                        else if (GetName().substr(0, 4) == "brid"
-                            && (color == 147))
-                            mPush.emplace_back(false);
-                        else if (GetName().substr(0, 4) == "temp"
-                            && (color == 218
-                            || color == 220
-                            || color == 221))
-                            mPush.emplace_back(false);
-                        else if (GetName().substr(0, 6) == "church"
-                            && (color == 191
-                            || color == 0))
-                            mPush.emplace_back(false);
-                        else if (GetName().substr(0, 6) == "ground")
-                            mPush.emplace_back(false);
-                        else
-                            mPush.emplace_back(true);
+                        for (const auto& face : faceOption.mFaces)
+                        {
+                            mFaces.emplace_back(face);
+                        }
+                        for (const auto& palette : faceOption.mPalettes)
+                        {
+                            mPalettes.emplace_back(palette);
+                        }
+                        for (const auto& colorVec : faceOption.mFaceColors)
+                        {
+                            const auto color = colorVec.x;
+                            mColors.emplace_back(color);
+                            if ((GetName().substr(0, 5) == "house"
+                                || GetName().substr(0, 3) == "inn")
+                                && (color == 190
+                                || color == 191))
+                                mPush.emplace_back(false);
+                            else if (GetName().substr(0, 4) == "blck"
+                                && (color == 145
+                                || color == 191))
+                                mPush.emplace_back(false);
+                            else if (GetName().substr(0, 4) == "brid"
+                                && (color == 147))
+                                mPush.emplace_back(false);
+                            else if (GetName().substr(0, 4) == "temp"
+                                && (color == 218
+                                || color == 220
+                                || color == 221))
+                                mPush.emplace_back(false);
+                            else if (GetName().substr(0, 6) == "church"
+                                && (color == 191
+                                || color == 0))
+                                mPush.emplace_back(false);
+                            else if (GetName().substr(0, 6) == "ground")
+                                mPush.emplace_back(false);
+                            else
+                                mPush.emplace_back(true);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Render 3d lines by generating a quad for the line. Currently they are all a fixed width. They should be wider for catapult, thinner for rift gate and corn, etc.