### PR TITLE
Issue #106 Collector quest bug

### DIFF
--- a/app/display_gds.cpp
+++ b/app/display_gds.cpp
@@ -12,6 +12,9 @@ int main(int argc, char** argv)
     Logging::LogState::Disable("DialogStore");
     Logging::LogState::Disable("LoadScenes");
     Logging::LogState::Disable("LoadSceneIndices");
+    Logging::LogState::Disable("FileDataProvider");
+    Logging::LogState::Disable("PackedFileDataProvider");
+    Logging::LogState::Disable("CreateFileBuffer");
     
     std::string gdsFile{argv[1]};
 

--- a/bak/dialog.cpp
+++ b/bak/dialog.cpp
@@ -68,7 +68,7 @@ std::string_view Keywords::GetNPCName(unsigned i) const
 
 DialogSnippet::DialogSnippet(FileBuffer& fb, std::uint8_t dialogFile)
 {
-    const auto offset = fb.Tell();
+    const auto fileOffset = fb.Tell();
     mDisplayStyle        = fb.GetUint8();
     mActor               = fb.GetUint16LE();
     mDisplayStyle2       = fb.GetUint8();
@@ -91,7 +91,7 @@ DialogSnippet::DialogSnippet(FileBuffer& fb, std::uint8_t dialogFile)
     // DIRTY HACK BUT THE GAME IS WEIRD
     // This choice seems to be missing on the repair dialog (0x1b7763)
     // dont think this will work with anything but english translation
-    if (dialogFile == 18 && offset == 0x185b2)
+    if (dialogFile == 18 && fileOffset == 0x185b2)
     {
         // Manually add "CantAfford" choice here
         mChoices.emplace_back(0x7533, 0x1, 0xffff, KeyTarget{0});
@@ -103,12 +103,11 @@ DialogSnippet::DialogSnippet(FileBuffer& fb, std::uint8_t dialogFile)
         const auto choice0 = fb.GetUint16LE();
         const auto choice1 = fb.GetUint16LE();
         const auto offset  = fb.GetUint32LE();
-        const auto target  = GetTarget(offset);
-        if (offset != 0)
-            mChoices.emplace_back(state, choice0, choice1, target);
+        const auto target  = offset != 0 ? GetTarget(offset) : KeyTarget{0};
+        mChoices.emplace_back(state, choice0, choice1, target);
     }
 
-    if (dialogFile == 18 && offset == 0x1665f)
+    if (dialogFile == 18 && fileOffset == 0x1665f)
     {
         // Manually add "Haggle" choice here
         mChoices.emplace_back(0x106, 0x1, 0xffff, KeyTarget{0});

--- a/bak/screens.hpp
+++ b/bak/screens.hpp
@@ -80,8 +80,15 @@ void ShowDialogGui(
         //    ImGui::SameLine(); ImGui::Text(ss.str().c_str());
         //}
 
-        ImGui::TextWrapped(dialogStore.GetFirstText(
-            dialogStore.GetSnippet(choice.mTarget)).substr(0, 40).data());
+        if (evaluate_if<BAK::KeyTarget>(choice.mTarget, [](const auto& current){ return current != BAK::KeyTarget{0}; }))
+        {
+            ImGui::TextWrapped(dialogStore.GetFirstText(
+                dialogStore.GetSnippet(choice.mTarget)).substr(0, 40).data());
+        }
+        else
+        {
+            ImGui::TextWrapped("No text");
+        }
     }
 
     ImGui::End();

--- a/gui/gdsScene.cpp
+++ b/gui/gdsScene.cpp
@@ -64,7 +64,6 @@ GDSScene::GDSScene(
         font,
         gameState},
     mState{State::Idle},
-    mPendingInn{},
     mPendingGoto{},
     mKickedOut{false},
     mTemple{
@@ -275,14 +274,14 @@ void GDSScene::HandleHotspotLeftClicked(const BAK::Hotspot& hotspot)
         mLogger.Debug() << "Inn hotspot: " << hotspot << "\n";
         if (hotspot.mActionArg3 != 0)
         {
-            StartDialog(BAK::KeyTarget{hotspot.mActionArg3}, false);
             mState = State::Inn;
-            mPendingInn = hotspot;
+            StartDialog(BAK::KeyTarget{hotspot.mActionArg3}, false);
         }
         else
         {
             DoInn();
         }
+        mLogger.Debug() << "State now: " << static_cast<unsigned>(mState) << "\n";
     }
     else if (hotspot.mAction == BAK::HotspotAction::LUTE)
     {
@@ -322,6 +321,8 @@ void GDSScene::StartDialog(const BAK::Target target, bool isTooltip)
 
 void GDSScene::DialogFinished(const std::optional<BAK::ChoiceIndex>& choice)
 {
+    mLogger.Debug() << "Dialog finished with choice: " << choice
+        << " state: " << static_cast<unsigned>(mState) << "\n";
     if (mState == State::Bard)
     {
         AudioA::AudioManager::Get().PopTrack();
@@ -339,7 +340,6 @@ void GDSScene::DialogFinished(const std::optional<BAK::ChoiceIndex>& choice)
     else if (mState == State::Inn)
     {
         DoInn();
-        mPendingInn.reset();
     }
     else if (mState == State::Repair)
     {
@@ -416,6 +416,7 @@ void GDSScene::DoInn()
     assert(container && container->IsShop());
     auto& shopStats = container->GetShop();
     mGuiManager.ShowCamp(true, &container->GetShop());
+    mState = State::Idle;
 }
 
 void GDSScene::DoBard()

--- a/gui/gdsScene.hpp
+++ b/gui/gdsScene.hpp
@@ -83,7 +83,6 @@ public:
     DialogDisplay mDialogDisplay;
 
     State mState;
-    std::optional<BAK::Hotspot> mPendingInn;
     std::optional<BAK::HotspotRef> mPendingGoto;
     // e.g. when you fail barding
     bool mKickedOut;


### PR DESCRIPTION
Turns out many dialogs have a dialog choice pointing to KeyTarget{0}. This just indicates that the choice causes the dialog to be finished. Because we were
missing this choice in the collector quest dialog we were not skipping the dialog when the state was set.