### PR TITLE
Closes #153 Display world objects that are not present in WLD files

### DIFF
--- a/app/display_save.cpp
+++ b/app/display_save.cpp
@@ -22,7 +22,7 @@ int main(int argc, char** argv)
     logger.Info() << "Location: " << std::hex << gameData.mLocation.mLocation << std::dec << "\n";
     logger.Info() << "Location: " << gameData.mLocation.mLocation << "\n";
 
-    auto containers = gameData.LoadContainers(12);
+    auto containers = gameData.LoadContainers(1);
     logger.Info() << "Containers: \n";
     for (auto& con : containers)
     {

--- a/app/display_save.cpp
+++ b/app/display_save.cpp
@@ -22,7 +22,7 @@ int main(int argc, char** argv)
     logger.Info() << "Location: " << std::hex << gameData.mLocation.mLocation << std::dec << "\n";
     logger.Info() << "Location: " << gameData.mLocation.mLocation << "\n";
 
-    auto containers = gameData.LoadContainers(1);
+    auto containers = gameData.LoadContainers(7);
     logger.Info() << "Containers: \n";
     for (auto& con : containers)
     {

--- a/bak/container.cpp
+++ b/bak/container.cpp
@@ -10,11 +10,21 @@ namespace BAK {
 
 std::ostream& operator<<(std::ostream& os, const ContainerWorldLocation& loc)
 {
-    os << "CWL { Z: " << loc.mZone << " from: " << +(loc.mChapterRange >> 4) 
-        << " to: " << +(loc.mChapterRange & 0xf)
+    os << "CWL { Z: " << loc.mZone << " from: " << loc.GetFrom() 
+        << " to: " << loc.GetTo()
         << " model: " << +loc.mModel << " unk: " << std::hex << +loc.mUnknown << std::dec
         << " loc: " << loc.mLocation << "}";
     return os;
+}
+
+unsigned ContainerWorldLocation::GetFrom() const
+{
+    return (mChapterRange >> 4) & 0xf;
+}
+
+unsigned ContainerWorldLocation::GetTo() const
+{
+    return mChapterRange & 0xf;
 }
 
 std::ostream& operator<<(std::ostream& os, const ContainerGDSLocation& loc)
@@ -148,6 +158,24 @@ unsigned ContainerHeader::GetCombatantNumber() const
 {
     ASSERT(std::holds_alternative<ContainerCombatLocation>(mLocation));
     return std::get<ContainerCombatLocation>(mLocation).mCombatant;
+}
+
+unsigned ContainerHeader::GetModel() const
+{
+    assert(std::holds_alternative<ContainerWorldLocation>(mLocation));
+    return std::get<ContainerWorldLocation>(mLocation).mModel;
+}
+
+bool ContainerHeader::PresentInChapter(Chapter chapter) const
+{
+    if (std::holds_alternative<ContainerWorldLocation>(mLocation))
+    {
+        auto& location = std::get<ContainerWorldLocation>(mLocation);
+        return (chapter.mValue <= location.GetTo())
+            && (chapter.mValue >= location.GetFrom());
+    }
+    // FIXME: Double check if this applies to other container types
+    return true;
 }
 
 std::ostream& operator<<(std::ostream& os, const ContainerEncounter& ce)

--- a/bak/container.cpp
+++ b/bak/container.cpp
@@ -170,7 +170,7 @@ bool ContainerHeader::PresentInChapter(Chapter chapter) const
 {
     if (std::holds_alternative<ContainerWorldLocation>(mLocation))
     {
-        auto& location = std::get<ContainerWorldLocation>(mLocation);
+        const auto& location = std::get<ContainerWorldLocation>(mLocation);
         return (chapter.mValue <= location.GetTo())
             && (chapter.mValue >= location.GetFrom());
     }

--- a/bak/container.hpp
+++ b/bak/container.hpp
@@ -36,6 +36,9 @@ struct ContainerWorldLocation
     std::uint8_t mModel;
     std::uint8_t mUnknown;
     glm::uvec2 mLocation;
+
+    unsigned GetFrom() const;
+    unsigned GetTo() const;
 };
 
 std::ostream& operator<<(std::ostream&, const ContainerWorldLocation&);
@@ -82,6 +85,8 @@ public:
     HotspotRef GetHotspotRef() const;
     unsigned GetCombatNumber() const;
     unsigned GetCombatantNumber() const;
+    unsigned GetModel() const;
+    bool PresentInChapter(Chapter) const;
 
     bool HasLock() const { return CheckBitSet(mFlags, ContainerProperty::HasLock); }
     bool HasDialog() const { return CheckBitSet(mFlags, ContainerProperty::HasDialog); }

--- a/bak/dialogAction.cpp
+++ b/bak/dialogAction.cpp
@@ -99,7 +99,7 @@ std::ostream& operator<<(std::ostream& os, const LoseItem& action)
 std::ostream& operator<<(std::ostream& os, const GiveItem& action)
 {
     os << "GiveItem { what: " << +action.mItemIndex << " to: "
-        << +action.mCharacter << " amount: " << +action.mQuantity
+        << +action.mWho << " amount: " << +action.mQuantity
         << " rest[" << std::hex << action.mRest << std::dec << "]}";
     return os;
 }

--- a/bak/dialogAction.hpp
+++ b/bak/dialogAction.hpp
@@ -92,8 +92,7 @@ struct LoseItem
 struct GiveItem
 {
     std::uint8_t mItemIndex;
-    // if 2 then give to text variable set character
-    std::uint8_t mCharacter; 
+    std::uint8_t mWho; 
     std::uint16_t mQuantity;
     std::array<std::uint8_t, 4> mRest;
 };

--- a/bak/encounter/combat.ipp
+++ b/bak/encounter/combat.ipp
@@ -38,7 +38,7 @@ void GenericCombatFactory<isTrap>::Load()
     logger.Debug() << "Combats: " << count <<"\n";
     for (unsigned i = 0; i < count; i++)
     {
-        logger.Debug() << "Combat #" << i << " @" 
+        logger.Spam() << "Combat #" << i << " @" 
             << std::hex << fb.Tell() << std::dec << "\n";
         fb.Skip(3);
         const auto combatIndex = fb.GetUint32LE();

--- a/bak/entityType.cpp
+++ b/bak/entityType.cpp
@@ -25,4 +25,12 @@ unsigned GetContainerTypeFromEntityType(EntityType et)
     }
 }
 
+EntityType EntityTypeFromModelName(std::string_view name)
+{
+    if (name.substr(0, 3) == "box") return EntityType::CHEST;
+    if (name.substr(0, 5) == "chest") return EntityType::CHEST;
+    if (name.substr(0, 4) == "gate") return EntityType::GATE;
+    if (name.substr(0, 5) == "stump") return EntityType::STUMP;
+    return EntityType::CHEST;
+}
 }

--- a/bak/entityType.hpp
+++ b/bak/entityType.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string_view>
+
 namespace BAK {
 
 enum class EntityType
@@ -49,5 +51,6 @@ enum class EntityType
 };
 
 unsigned GetContainerTypeFromEntityType(EntityType);
+EntityType EntityTypeFromModelName(std::string_view name);
 
 }

--- a/bak/gameData.cpp
+++ b/bak/gameData.cpp
@@ -372,7 +372,7 @@ void GameData::LoadCombatEntityLists()
 {
     mBuffer.Seek(sCombatEntityListOffset);
 
-    mLogger.Info() << "Combat Entity Lists Start @" 
+    mLogger.Spam() << "Combat Entity Lists Start @" 
         << std::hex << sCombatEntityListOffset << std::dec << std::endl;
 
     for (int i = 0; i < sCombatEntityListCount; i++)
@@ -388,10 +388,10 @@ void GameData::LoadCombatEntityLists()
                 ss << sep << combatant;
             sep = ',';
         }
-        mLogger.Info() << ss.str() << std::endl;
+        mLogger.Spam() << ss.str() << std::endl;
     }
 
-    mLogger.Info() << "Combat Entity Lists End @" 
+    mLogger.Spam() << "Combat Entity Lists End @" 
         << std::hex << mBuffer.Tell() << std::dec << std::endl;
 }
 
@@ -399,15 +399,15 @@ void GameData::LoadCombatStats(unsigned offset, unsigned num)
 {
     unsigned combatStatsStart = offset;
     mBuffer.Seek(combatStatsStart);
-    mLogger.Info() << "Combat Stats Start @" 
+    mLogger.Spam() << "Combat Stats Start @" 
         << std::hex << combatStatsStart << std::dec << std::endl;
 
     // ends at 3070a
     for (unsigned i = 0; i < num; i++)
     {
-        mLogger.Info() << "Combat #" << std::dec << i 
+        mLogger.Spam() << "Combat #" << std::dec << i 
             << " " << std::hex << mBuffer.Tell() << std::endl;
-        mLogger.Info() << std::hex << mBuffer.GetUint16LE() << std::endl << std::dec;
+        mLogger.Spam() << std::hex << mBuffer.GetUint16LE() << std::endl << std::dec;
         auto spells = Spells(mBuffer.GetArray<6>());
 
         std::stringstream ss{""};
@@ -422,16 +422,16 @@ void GameData::LoadCombatStats(unsigned offset, unsigned num)
             mBuffer.Skip(2);
         }
         mBuffer.Skip(7); // Conditions?
-        mLogger.Info() << ss.str() << std::endl;
+        mLogger.Spam() << ss.str() << std::endl;
     }
-    mLogger.Info() << "Combat Stats End @" 
+    mLogger.Spam() << "Combat Stats End @" 
         << std::hex << mBuffer.Tell() << std::dec << std::endl;
 }
 
 void GameData::LoadCombatGridLocations()
 {
     const auto initial = 0;
-    mLogger.Info() << "Loading Combat Grid Locations" << std::endl;
+    mLogger.Spam() << "Loading Combat Grid Locations" << std::endl;
     mBuffer.Seek(sCombatGridLocationsOffset + (initial * 22));
     for (unsigned i = 0; i < sCombatGridLocationsCount; i++)
     {
@@ -441,7 +441,7 @@ void GameData::LoadCombatGridLocations()
         const auto gridY = mBuffer.GetUint8();
         mBuffer.Skip(16);
 
-        mLogger.Info() << "Combat #" << i << " monster: " << monsterType <<
+        mLogger.Spam() << "Combat #" << i << " monster: " << monsterType <<
             " grid: " << glm::uvec2{gridX, gridY} << "\n";
     }
 }
@@ -462,7 +462,7 @@ void GameData::LoadCombatWorldLocations()
         // 3 - moving
         // 4 - dead
         const auto combatantState = mBuffer.GetUint8();
-        mLogger.Info() << "Combatant: " << k << " Position: " << combatantPosition << 
+        mLogger.Spam() << "Combatant: " << k << " Position: " << combatantPosition << 
             " unknown: " << + unknownFlag <<
             " state: " << +combatantState << std::endl;
     }

--- a/bak/gameState.cpp
+++ b/bak/gameState.cpp
@@ -549,8 +549,17 @@ void GameState::EvaluateAction(const DialogAction& action)
         [&](const GiveItem& give)
         {
             mLogger.Debug() << "Giving item: " << give << "\n";
-            auto& party = GetParty();
-            party.GainItem(give.mCharacter, give.mItemIndex, give.mQuantity);
+            if (give.mWho <= 1)
+            {
+                auto& party = GetParty();
+                party.GainItem(give.mItemIndex, give.mQuantity);
+            }
+            else
+            {
+                auto characterToGive = mDialogCharacterList[give.mWho - 2];
+                GetParty().GetCharacter(CharIndex{characterToGive}).GiveItem(
+                    InventoryItemFactory::MakeItem(ItemIndex{give.mItemIndex}, give.mQuantity));
+            }
         },
         [&](const GainSkill& skill)
         {

--- a/bak/inventory.cpp
+++ b/bak/inventory.cpp
@@ -200,6 +200,7 @@ void Inventory::CheckPostConditions()
         // We should never end up with a stack bigger than allowed
         if (item.IsStackable())
         {
+            // The game actually does not enforce this at all...
             ASSERT(item.GetQuantity() <= item.GetObject().mStackSize);
             ASSERT(item.GetQuantity() > 0);
         }

--- a/bak/zone.hpp
+++ b/bak/zone.hpp
@@ -42,7 +42,6 @@ public:
                     mPalette));
         }
 
-
         const auto cube = Graphics::Cuboid{1, 1, 50};
         mObjects.AddObject("Combat", cube.ToMeshObject(glm::vec4{1.0, 0, 0, .3}));
         mObjects.AddObject("Trap", cube.ToMeshObject(glm::vec4{.8, 0, 0, .3}));

--- a/game/console.hpp
+++ b/game/console.hpp
@@ -347,7 +347,6 @@ struct Console : public std::streambuf
         }
 
         mGameState->GetParty().GainItem(
-            1,
             itemIndex,
             amount);
     }


### PR DESCRIPTION
Some objects are not present in the WLD files, these need to be manually added to the map when this is detected. Additionally some only appear in certain chapters. e.g. Rift gate in ch7. The model information is part of the ContainerWorldLocation header so we have all the info we need to place these on the map.