### PR TITLE
Closes #247 - fix skill persistence

### DIFF
--- a/app/config.cpp
+++ b/app/config.cpp
@@ -53,6 +53,13 @@ Logging LoadLogging(const nlohmann::json& config)
                 logging.mDisabledLoggers.emplace_back(logger);
             }
         }
+        if (c.contains("EnabledLoggers"))
+        {
+            for (const auto& logger : c["EnabledLoggers"])
+            {
+                logging.mEnabledLoggers.emplace_back(logger);
+            }
+        }
     }
     return logging;
 }

--- a/app/config.hpp
+++ b/app/config.hpp
@@ -30,6 +30,7 @@ struct Logging
     std::string mLogFilePath{};
     std::string mLogLevel{"DEBUG"};
     std::vector<std::string> mDisabledLoggers{};
+    std::vector<std::string> mEnabledLoggers{};
 };
 
 struct Audio

--- a/app/display_save.cpp
+++ b/app/display_save.cpp
@@ -34,7 +34,10 @@ struct Options
     bool combat_lists{};
 
     std::string saveFile{};
+    std::string character{};
 };
+
+static constexpr int CHARACTER_OPT = 1000;
 
 Options Parse(int argc, char** argv)
 {
@@ -55,6 +58,7 @@ Options Parse(int argc, char** argv)
         {"combat_stats", no_argument, 0, 'S'},
         {"combat_click", no_argument, 0, 'C'},
         {"combat_lists", no_argument, 0, 'l'},
+        {"character", required_argument, 0, CHARACTER_OPT},
     };
     int optionIndex = 0;
     int opt;
@@ -63,7 +67,7 @@ Options Parse(int argc, char** argv)
         if (opt == 'h')
         {
             std::cout << "Arguments determine what information to display\n";
-            std::cout << "\t --all,-a        Show all information\n";
+            std::cout << "\t --all,-a Show all info\n";
             std::cout << "\t --shop,-s\n";
             std::cout << "\t --zone,-z\n";
             std::cout << "\t --party,-p\n";
@@ -76,6 +80,7 @@ Options Parse(int argc, char** argv)
             std::cout << "\t --combat_stats,-S\n";
             std::cout << "\t --combat_click,-C\n";
             std::cout << "\t --combat_lists,-l\n";
+            std::cout << "\t --character <name> Display character stats matching name\n";
             exit(0);
         }
         else if (opt == 'a')
@@ -134,6 +139,10 @@ Options Parse(int argc, char** argv)
         {
             values.combat_lists = true;
         }
+        else if (opt == CHARACTER_OPT)
+        {
+            values.character = optarg;
+        }
     }
 
     if (values.all)
@@ -186,6 +195,30 @@ int main(int argc, char** argv)
     {
         auto party = LoadParty(gameData.GetFileBuffer());
         logger.Info() << "Party: " << party << "\n";
+    }
+
+    if (!options.character.empty())
+    {
+        auto party = LoadParty(gameData.GetFileBuffer());
+        auto searchName = ToUpper(options.character);
+        bool found = false;
+        for (const auto& c : party.mCharacters)
+        {
+            if (ToUpper(c.mName).find(searchName) != std::string::npos)
+            {
+                logger.Info() << c << "\n";
+                found = true;
+            }
+        }
+        if (!found)
+        {
+            logger.Info() << "No character matching '" << options.character << "' found.\n";
+            logger.Info() << "Available characters:\n";
+            for (const auto& c : party.mCharacters)
+            {
+                logger.Info() << "  " << c.mName << "\n";
+            }
+        }
     }
 
     if (options.skill_affectors)

--- a/app/main3d.cpp
+++ b/app/main3d.cpp
@@ -187,6 +187,10 @@ int main(int argc, char** argv)
     {
         Logging::LogState::Disable(disabled);
     }
+    for (const auto& enabled : config.mLogging.mEnabledLoggers)
+    {
+        Logging::LogState::Enable(enabled);
+    }
     
     if (!config.mPaths.mGameData.empty())
     {

--- a/bak/gameData.hpp
+++ b/bak/gameData.hpp
@@ -38,7 +38,7 @@ public:
         mBuffer.Seek(0);
         mBuffer.PutString(saveName);
 
-        mLogger.Info() << "Saving game to: " << savePath << std::endl;
+        mLogger.Info() << "Saving [" << saveName << "] game to: " << savePath << std::endl;
         auto saveFile = std::ofstream{
             savePath,
             std::ios::binary | std::ios::out};

--- a/bak/save/character.cpp
+++ b/bak/save/character.cpp
@@ -140,8 +140,10 @@ void Save(const Character& c, FileBuffer& fb)
         fb.PutUint8(skill.mExperience);
         fb.PutUint8(skill.mModifier);
 
+        const auto pos = fb.Tell();
         State::SetSkillSelected(fb, charIndex, i, skill.mSelected);
         State::SetSkillUnseenImprovement(fb, charIndex, i, skill.mUnseenImprovement);
+        fb.Seek(pos);
     }
 
     // Inventory

--- a/com/logger.hpp
+++ b/com/logger.hpp
@@ -37,6 +37,11 @@ public:
         sDisabledLoggers.emplace_back(logger);
     }
 
+    static void Enable(const std::string& logger)
+    {
+        sEnabledLoggers.emplace_back(logger);
+    }
+
     static void SetLevel(LogLevel level)
     {
         sGlobalLogLevel = level;
@@ -82,14 +87,27 @@ public:
 
     static std::ostream& Log(LogLevel level, const std::string& loggerName)
     {
-        const auto it = std::find(
-            sDisabledLoggers.begin(), sDisabledLoggers.end(),
-            loggerName);
+        if (level < sGlobalLogLevel)
+            return nullStream;
 
-        if (level >= sGlobalLogLevel && it == sDisabledLoggers.end())
-            return DoLog(level, loggerName);
+        if (!sEnabledLoggers.empty())
+        {
+            const auto it = std::find(
+                sEnabledLoggers.begin(), sEnabledLoggers.end(),
+                loggerName);
+            if (it == sEnabledLoggers.end())
+                return nullStream;
+        }
+        else
+        {
+            const auto it = std::find(
+                sDisabledLoggers.begin(), sDisabledLoggers.end(),
+                loggerName);
+            if (it != sDisabledLoggers.end())
+                return nullStream;
+        }
 
-        return nullStream;
+        return DoLog(level, loggerName);
     }
     
     static const Logger& GetLogger(const std::string& name){ return GetLoggerT<Logger>(name); }

--- a/game/console.cpp
+++ b/game/console.cpp
@@ -484,6 +484,104 @@ void Console::SetLogLevel(const std::vector<std::string>& words)
     }
 }
 
+void Console::ListSkill(const std::vector<std::string>&)
+{
+    for (std::uint16_t i = 0; i <= static_cast<std::uint16_t>(BAK::SkillType::Stealth); i++)
+    {
+        AddLog("(%d) %s", i, BAK::ToString(static_cast<BAK::SkillType>(i)).data());
+    }
+}
+
+void Console::MaxAllSpells(const std::vector<std::string>& words)
+{
+    if (words.size() < 2)
+    {
+        std::stringstream ss{};
+        for (const auto& w : words)
+            ss << w << "|";
+        AddLog("[error] Usage: MAX_ALL_SPELLS ACTIVE_CHAR_INDEX (%s)", ss.str().c_str());
+        return;
+    }
+
+    std::uint16_t character;
+    {
+        std::stringstream ss{};
+        ss << words[1];
+        ss >> character;
+    }
+
+    if (character > 2)
+    {
+        AddLog("[error] Character must be between 0 and 2 (%d)", character);
+        return;
+    }
+
+    auto& charSpells = mGameState->GetParty().GetCharacter(BAK::ActiveCharIndex{character})
+        .GetSpells();
+    const auto& allSpells = BAK::SpellDatabase::Get().GetSpells();
+    for (const auto& spell : allSpells)
+    {
+        charSpells.SetSpell(spell.mIndex);
+    }
+    AddLog("All spells learned for character %d", character);
+}
+
+void Console::SetSkill(const std::vector<std::string>& words)
+{
+    if (words.size() < 4)
+    {
+        std::stringstream ss{};
+        for (const auto& w : words)
+            ss << w << "|";
+        AddLog("[error] Usage: SET_SKILL CHARACTER SKILL VALUE (%s)", ss.str().c_str());
+        return;
+    }
+
+    std::uint16_t character;
+    {
+        std::stringstream ss{};
+        ss << words[1];
+        ss >> character;
+    }
+
+    if (character > 2)
+    {
+        AddLog("[error] Character must be between 0 and 2 (%d)", character);
+	return;
+    }
+
+    std::uint16_t skill;
+    {
+        std::stringstream ss{};
+        ss << words[2];
+        ss >> skill;
+    }
+
+    if (skill > 15)
+    {
+        AddLog("[error] Skill must be between 0 and 15");
+	return;
+    }
+
+    std::uint16_t value;
+    {
+        std::stringstream ss{};
+        ss << words[3];
+        ss >> value;
+    }
+
+    auto& charSkills = mGameState->GetParty().GetCharacter(BAK::ActiveCharIndex{character})
+        .GetSkills();
+
+    auto& mySkill = charSkills.GetSkill(BAK::SkillType{skill});
+    mySkill.mMax = value;
+    mySkill.mTrueSkill = value;
+    mySkill.mCurrent = value;
+    mySkill.mExperience = 0;
+    mGameState->GetParty().GetCharacter(BAK::ActiveCharIndex{character})
+        .UpdateSkills();
+}
+
 void Console::DisableLogger(const std::vector<std::string>& words)
 {
     if (words.size() < 2)
@@ -571,6 +669,15 @@ Console::Console()
 
     mCommands.push_back("NEXT_CHAPTER");
     mCommandActions.emplace_back([this](const auto& cmd){ NextChapter(cmd); });
+
+    mCommands.push_back("SET_SKILL");
+    mCommandActions.emplace_back([this](const auto& cmd){ SetSkill(cmd); });
+
+    mCommands.push_back("LIST_SKILL");
+    mCommandActions.emplace_back([this](const auto& cmd){ ListSkill(cmd); });
+
+    mCommands.push_back("MAX_ALL_SPELLS");
+    mCommandActions.emplace_back([this](const auto& cmd){ MaxAllSpells(cmd); });
 
     mCommands.push_back("CLEAR");
     mCommandActions.emplace_back([this](const auto& cmd)

--- a/game/console.hpp
+++ b/game/console.hpp
@@ -46,6 +46,9 @@ struct Console : public std::streambuf
     void SetPosition(const std::vector<std::string>& words);
     void SetChapter(const std::vector<std::string>& words);
     void SetLogLevel(const std::vector<std::string>& words);
+    void SetSkill(const std::vector<std::string>& words);
+    void ListSkill(const std::vector<std::string>& words);
+    void MaxAllSpells(const std::vector<std::string>& words);
     
     void DisableLogger(const std::vector<std::string>& words);
     Console();


### PR DESCRIPTION
Skills were not being saved correctly. Discovered when testing new console functionality to set skills to arbitrary values. Also added some more commands MAX_SPELLS and LIST_SKILLS to the console. Added "EnabledLoggers" config option to have a whitelist of loggers - helps when debugging.