### PR TITLE
Issue #244 - Fix bug when loading when no save directory exists

### DIFF
--- a/bak/saveManager.cpp
+++ b/bak/saveManager.cpp
@@ -74,6 +74,17 @@ void SaveManager::RefreshSaves()
     mDirectories = MakeSaveDirectories();
 }
 
+void SaveManager::EnsureDefaultDirectory()
+{
+    if (!mDirectories.empty())
+        return;
+
+    auto directory = SaveDirectory{1, "SAVES", {}};
+    std::filesystem::create_directory(mSavePath / directory.GetPath());
+    mLogger.Info() << "Created default save directory: " << mSavePath / directory.GetPath() << std::endl;
+    RefreshSaves();
+}
+
 void SaveManager::RemoveDirectory(unsigned index)
 {
     mLogger.Info() << "Removing save directory: " << mDirectories.at(index) << "\n";

--- a/bak/saveManager.hpp
+++ b/bak/saveManager.hpp
@@ -42,6 +42,7 @@ public:
 
     const std::vector<SaveDirectory>& GetSaves() const;
     void RefreshSaves();
+    void EnsureDefaultDirectory();
 
     void RemoveDirectory(unsigned index);
     void RemoveSave(unsigned directory, unsigned save);

--- a/gui/clickButton.cpp
+++ b/gui/clickButton.cpp
@@ -113,6 +113,9 @@ void ClickButton::SetText(std::string_view label)
 
 bool ClickButton::OnMouseEvent(const MouseEvent& event)
 {
+    if (!mActive)
+        return false;
+
     const bool dirty = std::visit(overloaded{
         [this](const LeftMousePress& p){ return LeftMousePressed(p.mValue); },
         [this](const LeftMouseRelease& p){ return LeftMouseReleased(p.mValue); },

--- a/gui/colors.hpp
+++ b/gui/colors.hpp
@@ -14,6 +14,7 @@ constexpr auto frameMaroon      = glm::vec4{.300, .110, .094, 1};
 constexpr auto fontHighlight    = glm::vec4{.859, .780, .475, 1};
 constexpr auto fontLowlight     = glm::vec4{.302, .110, .094, 1};
 constexpr auto fontUnbold       = glm::vec4{.333, .271, .173, 1};
+constexpr auto fontInactive     = glm::vec4{.573, .380, .204, 1};
 constexpr auto fontEmphasis     = glm::vec4{.094, .125, .204, 1};
 
 constexpr auto fontWhiteHighlight = glm::vec4{.969, .780, .651, 1};

--- a/gui/mainMenuScreen.cpp
+++ b/gui/mainMenuScreen.cpp
@@ -130,9 +130,24 @@ void MainMenuScreen::EnterMainMenu(bool gameRunning)
 {
     mGameRunning = gameRunning;
 
+    UpdateRestoreButton();
     AddChildren();
 
     AudioA::GetAudioManager().ChangeMusicTrack(AudioA::MusicIndex{sMainMenuSong});
+}
+
+void MainMenuScreen::UpdateRestoreButton()
+{
+    if (mSaveScreen.HasSaves())
+    {
+        mRestore.SetText("#Restore Game");
+        mRestore.SetActive();
+    }
+    else
+    {
+        mRestore.SetText("\xf9Restore Game");
+        mRestore.SetInactive();
+    }
 }
 
 [[nodiscard]] bool MainMenuScreen::OnMouseEvent(const MouseEvent& event)

--- a/gui/mainMenuScreen.hpp
+++ b/gui/mainMenuScreen.hpp
@@ -43,6 +43,7 @@ public:
         const Font& font);
 
     void EnterMainMenu(bool gameRunning);
+    void UpdateRestoreButton();
     [[nodiscard]] bool OnMouseEvent(const MouseEvent& event) override;
 private:
     enum class State

--- a/gui/saveScreen.cpp
+++ b/gui/saveScreen.cpp
@@ -149,6 +149,12 @@ bool SaveScreen::OnMouseEvent(const MouseEvent& event)
     return handled;
 }
 
+bool SaveScreen::HasSaves()
+{
+    mSaveManager.RefreshSaves();
+    return !mSaveManager.GetSaves().empty();
+}
+
 void SaveScreen::SetSaveOrLoad(bool isSave)
 {
     mSaveManager.RefreshSaves();
@@ -156,6 +162,11 @@ void SaveScreen::SetSaveOrLoad(bool isSave)
     mIsSave = isSave;
     mDirectories.SetDimensions(glm::vec2{100, mIsSave ? 90 : 108});
     mFiles.SetDimensions(glm::vec2{160, mIsSave ? 90 : 108});
+
+    if (mIsSave && mSaveManager.GetSaves().empty())
+    {
+        mSaveManager.EnsureDefaultDirectory();
+    }
 
     if (!mSelectedDirectory || !mSelectedSave)
     {
@@ -178,6 +189,12 @@ void SaveScreen::SetSaveOrLoad(bool isSave)
         (mSelectedDirectory && mSelectedSave)
             ? mSaveManager.GetSaves().at(*mSelectedDirectory).mSaves.at(*mSelectedSave).mName
             : "");
+
+    if (mIsSave && mSelectedDirectory && !mSelectedSave)
+    {
+        mDirectorySaveInput.SetFocus(false);
+        mFileSaveInput.SetFocus(true);
+    }
 
     mRefreshSaves = true;
     mRefreshDirectories = true;
@@ -235,7 +252,7 @@ void SaveScreen::SaveGame(bool isBookmark)
 
 void SaveScreen::RestoreGame()
 {
-    assert(mSelectedDirectory && mSelectedSave);
+    if (!mSelectedDirectory || !mSelectedSave) return;
     const auto savePath = mSaveManager.GetSaves().at(*mSelectedDirectory)
         .mSaves.at(*mSelectedSave).mPath;
     std::invoke(mLoadSaveFn, savePath);

--- a/gui/saveScreen.hpp
+++ b/gui/saveScreen.hpp
@@ -49,6 +49,7 @@ public:
     
     bool OnMouseEvent(const MouseEvent& event) override;
     void SetSaveOrLoad(bool isSave);
+    bool HasSaves();
 private:
     void RemoveDirectory();
     void RemoveFile();

--- a/gui/textBox.cpp
+++ b/gui/textBox.cpp
@@ -70,6 +70,7 @@ std::pair<glm::vec2, std::string_view> TextBox::SetText(
     auto emphasis = false;
     auto bold     = false;
     auto unbold   = false;
+    auto inactive = false;
     auto red      = false;
     auto white    = false;
     auto inWord   = false;
@@ -91,6 +92,7 @@ std::pair<glm::vec2, std::string_view> TextBox::SetText(
 
         italic = false;
         unbold = false;
+        inactive = false;
         red = false;
         white = false;
         emphasis = false;
@@ -215,6 +217,10 @@ std::pair<glm::vec2, std::string_view> TextBox::SetText(
         {
             unbold = !unbold;
         }
+        else if (c == static_cast<char>(0xf9))
+        {
+            inactive = !inactive;
+        }
         else if (c == static_cast<char>(0xf5))
         {
             red = !red;
@@ -257,6 +263,10 @@ std::pair<glm::vec2, std::string_view> TextBox::SetText(
                 // Maybe "lowlight", inactive
                 DrawBold(charPos, c, Color::black, Color::fontUnbold);
                 //DrawUnbold(charPos, c);
+            }
+            else if (inactive)
+            {
+                DrawBold(charPos, c, Color::buttonShadow, Color::fontInactive);
             }
             else if (red)
             {


### PR DESCRIPTION
Closes #224  - Implement correct BaK behaviour - when no save directory exists, grey out the "RestoreGame" button. When the user has started a game and wants to save, construct a default directory SAVES.G01.