### PR TITLE
Issues #66 #236 - Correctly dispatch combat from world objects

### DIFF
--- a/bak/combat.cpp
+++ b/bak/combat.cpp
@@ -11,11 +11,23 @@
 
 namespace BAK {
 
+std::string_view ToString(CombatantWorldState s)
+{
+    switch (s)
+    {
+        case CombatantWorldState::Invisible0: return "Invisible0";
+        case CombatantWorldState::Invisible1: return "Invisible1";
+        case CombatantWorldState::Moving0: return "Moving0";
+        case CombatantWorldState::Moving1: return "Moving1";
+        case CombatantWorldState::Dead: return "Dead";
+    }
+    return "Unknown";
+}
 
 std::ostream& operator<<(std::ostream& os, const CombatWorldLocation& cwl)
 {
     os << "CombatWorldLocation{" << cwl.mPosition << " ImageIndex: " << +cwl.mImageIndex
-        << " State: " << +cwl.mState << "}";
+        << " State: " << ToString(cwl.mState) << "}";
     return os;
 }
 

--- a/bak/combat.hpp
+++ b/bak/combat.hpp
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <iosfwd>
+#include <string_view>
 
 namespace BAK {
 
@@ -15,6 +16,8 @@ enum class CombatantWorldState : std::uint8_t
     Dead
 };
 
+std::string_view ToString(CombatantWorldState);
+
 class CombatWorldLocation
 {
 public:
@@ -23,12 +26,7 @@ public:
     // controls which of these variants is displayed. As the
     // combatant moves the index changes to simulate movement.
     std::uint8_t mImageIndex;
-    // 0 - invisible?
-    // 1 - invisible?
-    // 2 - moving
-    // 3 - moving
-    // 4 - dead
-    std::uint8_t mState;
+    CombatantWorldState mState;
 };
 
 std::ostream& operator<<(std::ostream&, const CombatWorldLocation&);

--- a/bak/dialogAction.hpp
+++ b/bak/dialogAction.hpp
@@ -49,7 +49,14 @@ enum class SpecialActionType : std::uint16_t
     ReduceGold = 0, // reduces party gold by val of item or to 0 if lt
     IncreaseGold = 1,
     RepairAllEquippedArmor = 2,
+    // handleSpecialAction is IDA function
+    // From dialog key: 0x1cfe0e (Lord Lyton tax collectors)
+    //++ SpecialAction{ Type: ResetCombatState [151, 0, 0]}
+    //++ SpecialAction{ Type: ResetCombatState [152, 0, 0]}
+
     ResetCombatState = 3,
+    // From dialog key: 2191e8 (nighthawk self poisons)
+    // ++ SpecialAction{ Type: SetCombatState [645, 0, 0]}
     SetCombatState = 4,
     CopyStandardInnToShop0 = 5,
     CopyStandardInnToShop1 = 6,
@@ -58,6 +65,9 @@ enum class SpecialActionType : std::uint16_t
     RepairAndBlessEquippedSwords = 9, // this does something funky with inventory
     ReturnAlcoholToShops = 10,
     ResetGambleValueTo = 11,
+    // From dialog key: 0x1cfe16 (man in dimwood with conjured scorpion combat)
+    // ++ SpecialAction{ Type: ResetCombatState [375, 0, 0]}
+    // ++ SpecialAction{ Type: BeginCombat [0, 0, 0]}
     BeginCombat = 12,
     ExtinguishAllLightSources = 13, // seems to expire TESs
     EmptyArlieContainer = 14,

--- a/bak/encounter/combat.ipp
+++ b/bak/encounter/combat.ipp
@@ -97,7 +97,10 @@ void GenericCombatFactory<isTrap>::Load()
         }
 
         auto unknown = fb.GetUint16LE();
-        const bool isAmbush = fb.GetUint16LE() == 0x1;
+        assert(unknown == 0);
+        auto ambushVar = fb.GetUint16LE();
+        assert(ambushVar == 0 || ambushVar == 1);
+        const bool isAmbush = ambushVar == 0x1;
 
         mCombats.emplace_back(
             combatIndex,

--- a/bak/gameState.hpp
+++ b/bak/gameState.hpp
@@ -178,6 +178,10 @@ public:
         std::uint8_t encounterIndex,
         std::uint8_t combatantRelativeIndex);
 
+    // Super lame, but BaK uses a global so I will too
+    void SetCombatTriggeredFromInteractable(bool value) { mCombatTriggeredFromInteractable = value; }
+    bool GetCombatTriggeredFromInteractable() const { return mCombatTriggeredFromInteractable; }
+
 private:
     std::optional<CharIndex> mDialogCharacter{};
     CharIndex mActiveCharacter{};
@@ -199,6 +203,7 @@ private:
     Royals mItemValue_753e{};
     unsigned mSkillValue{};
     unsigned mContextVar_753f{};
+    bool mCombatTriggeredFromInteractable{};
 
     std::optional<InventoryItem> mSelectedItem{};
     std::optional<MonsterIndex> mCurrentMonster{};

--- a/bak/save/combat.cpp
+++ b/bak/save/combat.cpp
@@ -128,7 +128,7 @@ std::vector<CombatWorldLocation> LoadCombatWorldLocations(FileBuffer& fb)
         const auto heading = static_cast<std::uint16_t>(fb.GetUint16LE() >> 8);
         const auto combatantPosition = GamePositionAndHeading{{x, y}, heading};
         const auto imageIndex = fb.GetUint8();
-        const auto combatantState = fb.GetUint8();
+        const auto combatantState = CombatantWorldState{fb.GetUint8()};
         data.emplace_back(CombatWorldLocation{combatantPosition, imageIndex, combatantState});
         logger.Spam() << "CWL #" << k << " " << data.back() << "\n";
     }
@@ -162,7 +162,7 @@ void Save(const std::vector<CombatWorldLocation>& cwls, FileBuffer& fb)
         fb.PutUint32LE(cwl.mPosition.mPosition.y);
         fb.PutUint16LE(cwl.mPosition.mHeading << 8);
         fb.PutUint8(cwl.mImageIndex);
-        fb.PutUint8(cwl.mState);
+        fb.PutUint8(std::to_underlying(cwl.mState));
     }
 }
 

--- a/game/combatEncounterHandler.cpp
+++ b/game/combatEncounterHandler.cpp
@@ -31,6 +31,33 @@ void CombatEncounterHandler::SetEnterCombatCallback(std::function<void()>&& call
     mEnterCombatCallback = std::move(callback);
 }
 
+bool CombatEncounterHandler::CombatIsUnavoidable(BAK::CombatIndex combatIndex)
+{
+    if (mGameState.GetCombatTriggeredFromInteractable())
+    {
+        return true;
+    }
+
+    switch (combatIndex.mValue)
+    {
+        case 151: [[fallthrough]];
+        case 152: [[fallthrough]];
+        case 235: [[fallthrough]];
+        case 245: [[fallthrough]];
+        case 291: [[fallthrough]];
+        case 293: [[fallthrough]];
+        case 335: [[fallthrough]];
+        case 337: [[fallthrough]];
+        case 338: [[fallthrough]];
+        case 375: [[fallthrough]];
+        case 410: [[fallthrough]];
+        case 429: [[fallthrough]];
+        case 430:
+            return true;
+    }
+    return false;
+}
+
 CombatCheckResult CombatEncounterHandler::CheckCombatEncounter(
     const BAK::Encounter::Encounter& encounter,
     const BAK::Encounter::Combat& combat)
@@ -41,6 +68,13 @@ CombatCheckResult CombatEncounterHandler::CheckCombatEncounter(
         mLogger.Debug() << __FUNCTION__ << " Combat inactive\n";
         return CombatCheckResult(false, false);
     }
+
+    if (CombatIsUnavoidable(BAK::CombatIndex{combat.mCombatIndex}))
+    {
+        mLogger.Debug() << __FUNCTION__ << " Combat is unavoidable\n";
+        return CombatCheckResult(true, false);
+    }
+
 
     if (!combat.mIsAmbush)
     {
@@ -65,7 +99,7 @@ CombatCheckResult CombatEncounterHandler::CheckCombatEncounter(
                 const auto [character, scoutSkill] = mGameState.GetPartySkill(BAK::SkillType::Scouting, true);
                 mLogger.Debug() << __FUNCTION__ << " Trying to scout combat: "
                     << scoutSkill << " chance: " << chance << "\n";
-                if (scoutSkill > chance)
+                if (scoutSkill >= chance)
                 {
                     mGameState.GetParty().ImproveSkillForAll(
                         BAK::SkillType::Scouting, BAK::SkillChange::ExercisedSkill, 1);
@@ -94,26 +128,14 @@ CombatCheckResult CombatEncounterHandler::CheckCombatEncounter(
     }
 }
 
-void CombatEncounterHandler::CheckAndDoCombatEncounter(
-    const BAK::Encounter::Encounter& encounter,
+unsigned CombatEncounterHandler::CalculateAvoidanceStealth(
     const BAK::Encounter::Combat& combat)
 {
-    const auto [combatActive, combatScouted] = CheckCombatEncounter(encounter, combat);
-
-    mLogger.Debug() << __FUNCTION__ << " Combat checked, result: [" << combatActive << ", " << combatScouted << "]\n";
-
-    if (!combatActive)
-    {
-        mLogger.Debug() << __FUNCTION__ << " Combat not active, not doing it\n";
-        return;
-    }
-
     const auto [character, stealthSkill] = mGameState.GetPartySkill(BAK::SkillType::Stealth, false);
     auto lowestStealth = stealthSkill;
     if (lowestStealth < 0x5a) // 90
     {
-        lowestStealth *= 0x1e; // 30
-        lowestStealth += (lowestStealth / 100);
+        lowestStealth += (lowestStealth * 0x1e) / 100; // 30
     }
     if (lowestStealth > 0x5a) lowestStealth = 0x5a;
 
@@ -125,25 +147,63 @@ void CombatEncounterHandler::CheckAndDoCombatEncounter(
         }
     }
 
+    return lowestStealth;
+}
+
+bool CombatEncounterHandler::CheckAvoidCombatDueToStealth(
+    const BAK::Encounter::Encounter& encounter,
+    const BAK::Encounter::Combat& combat)
+{
+
+    auto stealth = CalculateAvoidanceStealth(combat);
     auto chance = GetRandomNumber(0, 0xfff) % 100;
-    if (lowestStealth > chance)
+    if (stealth >= chance)
     {
         mGameState.GetParty().ImproveSkillForAll(
             BAK::SkillType::Stealth, BAK::SkillChange::ExercisedSkill, 1);
 
         mLogger.Debug() << __FUNCTION__ << " Avoided combat due to stealth\n";
-        return;
+        return true;
     }
 
+    return false;
+}
+
+bool CombatEncounterHandler::CheckAndDoCombatEncounter(
+    const BAK::Encounter::Encounter& encounter,
+    const BAK::Encounter::Combat& combat)
+{
+    mLogger.Debug() << __FUNCTION__ << " Handling combat: " << combat << "\n";
+    const auto [combatActive, combatScouted] = CheckCombatEncounter(encounter, combat);
+
+    mLogger.Debug() << __FUNCTION__ << " Combat checked, result: [" << combatActive << ", " << combatScouted << "]\n";
+
+    if (!combatActive)
+    {
+        mLogger.Debug() << __FUNCTION__ << " Combat not active, not doing it\n";
+        return combatScouted;
+    }
+
+    if (!CombatIsUnavoidable(BAK::CombatIndex{combat.mCombatIndex}))
+    {
+        auto avoidedDueToStealth = CheckAvoidCombatDueToStealth(encounter, combat);
+        if (avoidedDueToStealth)
+        {
+            return true;
+        }
+    }
+
+    const auto [character, stealth] = mGameState.GetPartySkill(BAK::SkillType::Stealth, false);
     // Check whether players are in valid combatable position???
     auto timeOfScouting = mGameState.Apply(BAK::State::GetCombatClickedTime, combat.mCombatIndex);
     auto timeDiff = (mGameState.GetWorldTime().GetTime() - timeOfScouting).mTime;
     if ((timeDiff / 0x1e) < 0x1e) // within scouting valid time
     {
         auto chance = GetRandomNumber(0, 0xfff) % 100;
-        if (chance > lowestStealth)
+        if (chance > stealth)
         {
             // failed to sneak up
+            // mGameState.SetActiveCharacter(character);
             mGameState.SetDialogContext_7530(1);
         }
         else
@@ -181,6 +241,8 @@ void CombatEncounterHandler::CheckAndDoCombatEncounter(
             false,
             &mDynamicDialogScene);
     }
+
+    return true;
 }
 
 }

--- a/game/combatEncounterHandler.hpp
+++ b/game/combatEncounterHandler.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "bak/types.hpp"
+
 #include "com/logger.hpp"
 
 #include <glm/glm.hpp>
@@ -35,11 +37,20 @@ public:
         Gui::IGuiManager& guiManager,
         Gui::DynamicDialogScene& dynamicDialogScene);
 
+    bool CombatIsUnavoidable(BAK::CombatIndex);
+
     CombatCheckResult CheckCombatEncounter(
         const BAK::Encounter::Encounter& encounter,
         const BAK::Encounter::Combat& combat);
 
-    void CheckAndDoCombatEncounter(
+    unsigned CalculateAvoidanceStealth(
+        const BAK::Encounter::Combat& combat);
+
+    bool CheckAvoidCombatDueToStealth(
+        const BAK::Encounter::Encounter& encounter,
+        const BAK::Encounter::Combat& combat);
+
+    bool CheckAndDoCombatEncounter(
         const BAK::Encounter::Encounter& encounter,
         const BAK::Encounter::Combat& combat);
 

--- a/game/encounterHandler.cpp
+++ b/game/encounterHandler.cpp
@@ -47,34 +47,52 @@ void EncounterHandler::SetTransitionCallback(TransitionCallback&& callback)
     mTransitionCallback = std::move(callback);
 }
 
-void EncounterHandler::DoEncounter(const BAK::Encounter::Encounter& encounter)
+bool EncounterHandler::DoEncounter(const BAK::Encounter::Encounter& encounter)
 {
     mLogger.Spam() << "Doing Encounter: " << encounter << "\n";
-    std::visit(
+    return std::visit(
         overloaded{
         [&](const BAK::Encounter::GDSEntry& gds){
             if (mGuiManager.InMainView())
-                DoGDSEncounter(encounter, gds);
+            {
+                return DoGDSEncounter(encounter, gds);
+            }
+            return false;
         },
         [&](const BAK::Encounter::Block& block){
             if (mGuiManager.InMainView())
-                DoBlockEncounter(encounter, block);
+            {
+                return DoBlockEncounter(encounter, block);
+            }
+            return false;
         },
         [&](const BAK::Encounter::Combat& combat){
             if (mGuiManager.InMainView())
-                mCombatHandler.CheckAndDoCombatEncounter(encounter, combat);
+            {
+                return mCombatHandler.CheckAndDoCombatEncounter(encounter, combat);
+            }
+            return false;
         },
         [&](const BAK::Encounter::Dialog& dialog){
             if (mGuiManager.InMainView())
-                DoDialogEncounter(encounter, dialog);
+            {
+                return DoDialogEncounter(encounter, dialog);
+            }
+            return false;
         },
         [&](const BAK::Encounter::EventFlag& flag){
             if (mGuiManager.InMainView())
-                DoEventFlagEncounter(encounter, flag);
+            {
+                return DoEventFlagEncounter(encounter, flag);
+            }
+            return false;
         },
         [&](const BAK::Encounter::Zone& zone){
             if (mGuiManager.InMainView())
-                DoZoneEncounter(encounter, zone);
+            {
+                return DoZoneEncounter(encounter, zone);
+            }
+            return false;
         },
     },
     encounter.GetEncounter());
@@ -85,12 +103,14 @@ CombatEncounterHandler& EncounterHandler::GetCombatHandler()
     return mCombatHandler;
 }
 
-void EncounterHandler::DoBlockEncounter(
+bool EncounterHandler::DoBlockEncounter(
     const BAK::Encounter::Encounter& encounter,
     const BAK::Encounter::Block& block)
 {
     if (!BAK::State::CheckEncounterActive(mGameState, encounter, mGameState.GetZone()))
-        return;
+        return false;
+
+    mLogger.Info() << "DoBlockEncounter for: " << block << "\n";
 
     mGuiManager.StartDialog(
             block.mDialog,
@@ -103,14 +123,17 @@ void EncounterHandler::DoBlockEncounter(
         BAK::State::SetPostEnableOrDisableEventFlags,
         encounter,
         mGameState.GetZone());
+    return true;
 }
 
-void EncounterHandler::DoEventFlagEncounter(
+bool EncounterHandler::DoEventFlagEncounter(
     const BAK::Encounter::Encounter& encounter,
     const BAK::Encounter::EventFlag& flag)
 {
     if (!BAK::State::CheckEncounterActive(mGameState, encounter, mGameState.GetZone()))
-        return;
+        return false;
+
+    mLogger.Info() << "DoEventFlagEncounter for: " << flag << "\n";
 
     if (flag.mEventPointer != 0)
         mGameState.SetEventValue(flag.mEventPointer, flag.mIsEnable ? 1 : 0);
@@ -119,14 +142,15 @@ void EncounterHandler::DoEventFlagEncounter(
         BAK::State::SetPostEnableOrDisableEventFlags,
         encounter,
         mGameState.GetZone());
+    return true;
 }
 
-void EncounterHandler::DoZoneEncounter(
+bool EncounterHandler::DoZoneEncounter(
     const BAK::Encounter::Encounter& encounter,
     const BAK::Encounter::Zone& zone)
 {
     if (!BAK::State::CheckEncounterActive(mGameState, encounter, mGameState.GetZone()))
-        return;
+        return false;
     const auto& choices = BAK::DialogStore::Get().GetSnippet(zone.mDialog).mChoices;
     const bool isNoAffirmative = choices.size() == 2
         && std::holds_alternative<BAK::QueryChoice>(choices.begin()->mChoice)
@@ -157,14 +181,19 @@ void EncounterHandler::DoZoneEncounter(
         false,
         false,
         &mDynamicDialogScene);
+    return true;
 }
 
-void EncounterHandler::DoDialogEncounter(
+bool EncounterHandler::DoDialogEncounter(
     const BAK::Encounter::Encounter& encounter,
     const BAK::Encounter::Dialog& dialog)
 {
     if (!BAK::State::CheckEncounterActive(mGameState, encounter, mGameState.GetZone()))
-        return;
+    {
+        return false;
+    }
+
+    mLogger.Info() << "DoDialogEncounter for: " << dialog << "\n";
 
     mSavedAngle = mCamera.GetAngle();
     mDynamicDialogScene.SetDialogFinished(
@@ -183,12 +212,15 @@ void EncounterHandler::DoDialogEncounter(
         BAK::State::SetPostDialogEventFlags,
         encounter,
         mGameState.GetZone());
+
+    return true;
 }
 
-void EncounterHandler::DoGDSEncounter(
+bool EncounterHandler::DoGDSEncounter(
     const BAK::Encounter::Encounter& encounter,
     const BAK::Encounter::GDSEntry& gds)
 {
+    mLogger.Info() << "DoGdsEncounter for: " << gds << "\n";
     // Pretty sure GDS encoutners will always happen...
     //if (!mGameState.Apply(BAK::State::CheckEncounterActive, encounter, mGameState.GetZone()))
     //    return;
@@ -225,6 +257,7 @@ void EncounterHandler::DoGDSEncounter(
         false,
         false,
         &mDynamicDialogScene);
+    return true;
 }
 
 }

--- a/game/encounterHandler.hpp
+++ b/game/encounterHandler.hpp
@@ -44,24 +44,24 @@ public:
 
     void SetTransitionCallback(TransitionCallback&& callback);
 
-    void DoEncounter(const BAK::Encounter::Encounter& encounter);
+    bool DoEncounter(const BAK::Encounter::Encounter& encounter);
 
     CombatEncounterHandler& GetCombatHandler();
 
 private:
-    void DoBlockEncounter(
+    bool DoBlockEncounter(
         const BAK::Encounter::Encounter& encounter,
         const BAK::Encounter::Block& block);
-    void DoDialogEncounter(
+    bool DoDialogEncounter(
         const BAK::Encounter::Encounter& encounter,
         const BAK::Encounter::Dialog& dialog);
-    void DoZoneEncounter(
+    bool DoZoneEncounter(
         const BAK::Encounter::Encounter& encounter,
         const BAK::Encounter::Zone& zone);
-    void DoGDSEncounter(
+    bool DoGDSEncounter(
         const BAK::Encounter::Encounter& encounter,
         const BAK::Encounter::GDSEntry& gds);
-    void DoEventFlagEncounter(
+    bool DoEventFlagEncounter(
         const BAK::Encounter::Encounter& encounter,
         const BAK::Encounter::EventFlag& flag);
 

--- a/game/gameRunner.cpp
+++ b/game/gameRunner.cpp
@@ -44,7 +44,7 @@ GameRunner::GameRunner(
     mInteractableFactory{
         mGuiManager,
         mGameState,
-        [this](const auto& pos){ CheckAndDoEncounter(pos); }},
+        [this](const auto& pos) -> bool { return CheckAndDoEncounter(pos); }},
     mCurrentInteractable{nullptr},
     mZoneData{nullptr},
     mActiveEncounter{nullptr},
@@ -308,7 +308,7 @@ void GameRunner::LoadCombatants(std::uint8_t tileIndex)
             auto& cwl = mGameState.GetCombatWorldLocation(tileIndex, encounter.mIndex.mValue, i);
             // Combatants that aren't dead in a completed combat should not be shown
             if (combatComplete
-                && static_cast<BAK::CombatantWorldState>(cwl.mState) != BAK::CombatantWorldState::Dead)
+                && cwl.mState != BAK::CombatantWorldState::Dead)
             {
                 continue;
             }
@@ -320,7 +320,7 @@ void GameRunner::LoadCombatants(std::uint8_t tileIndex)
             }
 
             cwl.mImageIndex = 0;
-            cwl.mState = combatant.mMovementType;
+            cwl.mState = static_cast<BAK::CombatantWorldState>(combatant.mMovementType);
             cwl.mPosition = combatant.mLocation;
 
             auto entityId = mSystems->GetNextItemId();
@@ -448,7 +448,7 @@ void GameRunner::CombatCompleted(bool retreated, int combatResult)
 
         const auto& monster = *mCombatModelLoader.mCombatModels[it->mMonster.mValue];
         const auto deadFrameOffset = monster.GetAnimation(BAK::AnimationType::Dead, BAK::Direction::South).mImageIndices.size() - 1;
-        it->mCombatantBAKLocation.mState = std::to_underlying(BAK::CombatantWorldState::Dead);
+        it->mCombatantBAKLocation.mState = BAK::CombatantWorldState::Dead;
         it->mAnimationType = BAK::AnimationType::Dead;
         it->mFrame = deadFrameOffset;
         it->Update();
@@ -463,7 +463,7 @@ void GameRunner::EnterCombatFromEncounter()
     });
 }
 
-void GameRunner::CheckAndDoEncounter(glm::uvec2 position)
+bool GameRunner::CheckAndDoEncounter(glm::uvec2 position)
 {
     mLogger.Debug() << __FUNCTION__ << " Pos: " << position << "\n";
     auto intersectables = mSystems->RunIntersection(
@@ -476,9 +476,12 @@ void GameRunner::CheckAndDoEncounter(glm::uvec2 position)
             const auto* encounter = it->second;
             mActiveEncounter = encounter;
             if (mActiveEncounter)
-                mEncounterHandler.DoEncounter(*mActiveEncounter);
+            {
+                return mEncounterHandler.DoEncounter(*mActiveEncounter);
+            }
         }
     }
+    return false;
 }
 
 void GameRunner::RunGameUpdate(bool advanceTime)
@@ -600,7 +603,7 @@ void GameRunner::CleanCombatsOnNewZone()
     {
         cwl.mPosition = BAK::GamePositionAndHeading{};
         cwl.mImageIndex = 0;
-        cwl.mState = 1;
+        cwl.mState = BAK::CombatantWorldState::Invisible1;
     }
 }
 }

--- a/game/gameRunner.hpp
+++ b/game/gameRunner.hpp
@@ -88,7 +88,7 @@ public:
     void LoadSystems();
 
     void DoGenericContainer(BAK::EntityType et, BAK::GenericContainer& container);
-    void CheckAndDoEncounter(glm::uvec2 position);
+    bool CheckAndDoEncounter(glm::uvec2 position);
     
     void RunGameUpdate(bool advanceTime);
     void CheckClickable(unsigned entityId);

--- a/game/interactable/IInteractable.hpp
+++ b/game/interactable/IInteractable.hpp
@@ -5,7 +5,6 @@
 #include <glm/glm.hpp>
 
 #include <functional>
-#include <string_view>
 
 namespace BAK {
 class GenericContainer;
@@ -13,7 +12,7 @@ class GenericContainer;
 
 namespace Game {
 
-using EncounterCallback = std::function<void(glm::uvec2)>;
+using EncounterCallback = std::function<bool(glm::uvec2)>;
 
 class IInteractable
 {

--- a/game/interactable/building.cpp
+++ b/game/interactable/building.cpp
@@ -7,12 +7,13 @@
 #include "bak/dialog.hpp"
 #include "bak/dialogSources.hpp"
 #include "bak/gameState.hpp"
-#include "bak/itemNumbers.hpp"
 
 #include "com/logger.hpp"
 
 #include "gui/IDialogScene.hpp"
 #include "gui/IGuiManager.hpp"
+
+#include <utility>
 
 namespace Game::Interactable {
 
@@ -39,11 +40,10 @@ void Building::BeginInteraction(BAK::GenericContainer& building, BAK::EntityType
 
     ASSERT(mCurrentBuilding->HasDialog());
 
-    mGameState.SetDialogContext_7530(2);
+    mShowDialogFirst = CheckBitSet(mCurrentBuilding->GetDialog().mDialogOrder, 5); // test 0x20
 
-    if (!CheckBitSet(mCurrentBuilding->GetDialog().mDialogOrder, 5))
+    if (!mShowDialogFirst)
     {
-        // Skip dialog
         mState = State::SkipFirstDialog;
         Logging::LogDebug("Building") << "State: SkipFirstDialog\n";
         TryDoEncounter();
@@ -87,6 +87,12 @@ void Building::DialogFinished(const std::optional<BAK::ChoiceIndex>& choice)
     if (mState == State::DoFirstDialog)
     {
         Logging::LogDebug("Building") << "State: DoneFirstDialog: \n";
+        if (mGameState.GetEndOfDialogState() == -1)
+        {
+            Logging::LogDebug("Building") << "EndOfDialogState -1 -> exiting interaction early\n";
+            mState = State::Done;
+            return;
+        }
         TryDoEncounter();
         StartDialog(mCurrentBuilding->GetDialog().mDialog);
         return;
@@ -133,17 +139,27 @@ void Building::DialogFinished(const std::optional<BAK::ChoiceIndex>& choice)
 void Building::TryDoEncounter()
 {
     if (mCurrentBuilding->HasEncounter()
-    // Hack... probably there's a nicer way
-        && !mCurrentBuilding->GetEncounter().mHotspotRef)
+        && mCurrentBuilding->GetEncounter().mEncounterPos)
     {
         Logging::LogInfo("Building") << __FUNCTION__ << " " 
             << mCurrentBuilding->GetEncounter() << "\n";
-        std::invoke(
+
+        // Combats triggered from buildings should be unavoidable
+        mGameState.SetCombatTriggeredFromInteractable(true);
+        auto encounterActive = std::invoke(
             mEncounterCallback,
             *mCurrentBuilding->GetEncounter().mEncounterPos + glm::uvec2{600, 600});
-        // If this encounter is now inactive, we can run this dialog instead
-        //StartDialog(mCurrentBuilding->GetDialog().mDialog);
-        //mState = State::Done;
+        mGameState.SetCombatTriggeredFromInteractable(false);
+
+        if (!encounterActive)
+        {
+            if (mCurrentBuilding->GetDialog().mDialog != BAK::Target{BAK::KeyTarget{0}})
+            {
+                StartDialog(mCurrentBuilding->GetDialog().mDialog);
+                // is this the right state?
+                mState = State::Done;
+            }
+        }
     }
     else
     {
@@ -161,11 +177,21 @@ void Building::TryDoLock()
     }
     else
     {
+        auto forceDayContext = !CheckBitSet(mCurrentBuilding->GetDialog().mDialogOrder, 0);
+        auto isDayTime = mGameState.ReadEvent(std::to_underlying(BAK::ActiveStateFlag::DayTime));
+
+        mGameState.SetDialogContext_7530(
+            (forceDayContext || isDayTime) ? 0 : 1);
+
         mState = State::TryDoGDS;
-        if (!CheckBitSet(mCurrentBuilding->GetDialog().mDialogOrder, 5))
+        if (!mShowDialogFirst)
+        {
             StartDialog(mCurrentBuilding->GetDialog().mDialog);
+        }
         else
+        {
             TryDoGDS();
+        }
 
     }
 }

--- a/game/interactable/building.hpp
+++ b/game/interactable/building.hpp
@@ -60,6 +60,7 @@ private:
     Gui::DynamicDialogScene mDialogScene;
     BAK::GenericContainer* mCurrentBuilding;
     State mState;
+    bool mShowDialogFirst{false};
     const EncounterCallback& mEncounterCallback;
 };
 

--- a/game/interactable/chest.cpp
+++ b/game/interactable/chest.cpp
@@ -204,14 +204,6 @@ void Chest::Explode()
 
 void Chest::ShowChestContents()
 {
-    if (mCurrentChest->HasEncounter()
-        && mCurrentChest->GetEncounter().mSetEventFlag != 0)
-    {
-        mGameState.SetEventValue(
-            mCurrentChest->GetEncounter().mSetEventFlag,
-            1);
-    }
-
     mGuiManager.ShowContainer(mCurrentChest, BAK::EntityType::CHEST);
 }
 

--- a/game/interactable/tomb.cpp
+++ b/game/interactable/tomb.cpp
@@ -110,9 +110,16 @@ void Tomb::DoEncounter()
 {
     Logging::LogInfo("Tomb") << __FUNCTION__ << " " 
         << mCurrentTomb->GetEncounter() << "\n";
-    std::invoke(
+    mGameState.SetCombatTriggeredFromInteractable(true);
+    auto encounterActive = std::invoke(
         mEncounterCallback,
         *mCurrentTomb->GetEncounter().mEncounterPos);
+    mGameState.SetCombatTriggeredFromInteractable(false);
+
+    if (!encounterActive)
+    {
+        DigTomb();
+    }
 }
 
 void Tomb::EncounterFinished()
@@ -131,14 +138,6 @@ void Tomb::StartDialog(BAK::Target target)
 
 void Tomb::ShowTombContents()
 {
-    if (mCurrentTomb->HasEncounter()
-        && mCurrentTomb->GetEncounter().mSetEventFlag != 0)
-    {
-        mGameState.SetEventValue(
-            mCurrentTomb->GetEncounter().mSetEventFlag,
-            1);
-    }
-
     mGuiManager.ShowContainer(mCurrentTomb, BAK::EntityType::TOMBSTONE);
 }
 

--- a/gui/guiManager.cpp
+++ b/gui/guiManager.cpp
@@ -492,6 +492,11 @@ void GuiManager::ShowContainer(BAK::GenericContainer* container, BAK::EntityType
                 StartDialog(container->GetDialog().mDialog, false, false, mDialogScene);
             }
         }
+
+        if (container->HasEncounter() && container->GetEncounter().mSetEventFlag != 0)
+        {
+            mGameState.SetEventValue(container->GetEncounter().mSetEventFlag, 1);
+        }
     }});
 
     mInventoryScreen.SetSelectionMode(false, nullptr);


### PR DESCRIPTION
Combat was not being dispatched correctly from tombs and buildings.

Look into the assembly and fixed a bunch of small inconsistencies and corrected the behaviour of the building and tomb interactables.