### PR TITLE
Issue #255 Add option to correct the combat entity lists

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -8,6 +8,7 @@ list(APPEND APP_BINARIES
     #decomp_ttm
     dialog_explorer
     display_book
+    display_combat
     display_dialog
     display_encounters
     #display_fo

--- a/app/config.cpp
+++ b/app/config.cpp
@@ -86,6 +86,7 @@ Game LoadGame(const nlohmann::json& config)
     {
         const auto& c = config["Game"];
         game.mAdvanceTime = c.value("AdvanceTime", true);
+        game.mFixCombatEntityLists = c.value("FixCombatEntityLists", false);
     }
     return game;
 }

--- a/app/config.hpp
+++ b/app/config.hpp
@@ -45,6 +45,7 @@ struct Audio
 struct Game
 {
     bool mAdvanceTime{true};
+    bool mFixCombatEntityLists{false};
 };
 
 struct Config

--- a/app/display_combat.cpp
+++ b/app/display_combat.cpp
@@ -1,0 +1,21 @@
+#include "bak/encounter/combat.hpp"
+
+#include "com/logger.hpp"
+
+int main()
+{
+    const auto& logger = Logging::LogState::GetLogger("main");
+    Logging::LogState::SetLevel(Logging::LogLevel::Info);
+
+    BAK::Encounter::GenericCombatFactory<false> combatFactory;
+    logger.Info() << "=== DEF_COMB.DAT (" << combatFactory.size() << " combats) ===" << std::endl;
+    for (unsigned i = 0; i < combatFactory.size(); i++)
+        logger.Info() << i << ": " << combatFactory.Get(i) << std::endl;
+
+    BAK::Encounter::GenericCombatFactory<true> trapFactory;
+    logger.Info() << "\n=== DEF_TRAP.DAT (" << trapFactory.size() << " traps) ===" << std::endl;
+    for (unsigned i = 0; i < trapFactory.size(); i++)
+        logger.Info() << i << ": " << trapFactory.Get(i) << std::endl;
+
+    return 0;
+}

--- a/app/display_encounters.cpp
+++ b/app/display_encounters.cpp
@@ -10,7 +10,7 @@
 int main(int argc, char** argv)
 {
     const auto& logger = Logging::LogState::GetLogger("main");
-    Logging::LogState::SetLevel(Logging::LogLevel::Spam);
+    Logging::LogState::SetLevel(Logging::LogLevel::Info);
     
     BAK::Encounter::GenericCombatFactory<false>();
     BAK::Encounter::DialogFactory();
@@ -19,7 +19,7 @@ int main(int argc, char** argv)
     BAK::Encounter::EnableFactory();
     const auto ef = BAK::Encounter::EncounterFactory{};
 
-    for (unsigned zone = 1; zone < 12; zone++)
+    for (unsigned zone = 1; zone <= 12; zone++)
     {
         auto zoneLabel = BAK::ZoneLabel{zone};
         const auto tiles = BAK::LoadZoneRef(zoneLabel.GetZoneReference());
@@ -40,7 +40,9 @@ int main(int argc, char** argv)
                         const auto encounters = BAK::Encounter::LoadEncounters(
                                 ef, fb, BAK::Chapter{c}, glm::vec<2, unsigned>(x, y), tileIndex);
                         for (const auto& encounter : encounters)
+                        {
                             logger.Info() << "Encounter: " << encounter << "\n\n";
+                        }
                 }
             }
         }

--- a/app/display_req.cpp
+++ b/app/display_req.cpp
@@ -22,7 +22,7 @@ int main(int argc, char** argv)
     auto layout = BAK::Layout(reqFile);
 
     std::stringstream ss{};
-    ss << "i \t  widget \t action \t vis \t pos \t dim \t tele \t img \t grp \t label\n";
+    ss << "\ni \t  widget \t action \t vis \t pos \t dim \t tele \t img \t grp \t label\n";
     for (unsigned i = 0; i < layout.GetSize(); i++)
     {
         const auto& widget = layout.GetWidget(i);

--- a/app/main3d.cpp
+++ b/app/main3d.cpp
@@ -265,6 +265,7 @@ int main(int argc, char** argv)
         height / guiScalar};
         
     auto gameState = BAK::GameState{};
+    gameState.SetFixCombatEntityLists(config.mGame.mFixCombatEntityLists);
 
     auto guiManager = Gui::GuiManager{
         root.GetCursor(),

--- a/bak/encounter/combat.hpp
+++ b/bak/encounter/combat.hpp
@@ -141,6 +141,7 @@ public:
     GenericCombatFactory();
 
     const Combat& Get(unsigned i) const;
+    unsigned size() const { return mCombats.size(); }
 
 private:
     void Load();

--- a/bak/gameState.cpp
+++ b/bak/gameState.cpp
@@ -9,9 +9,10 @@
 #include "bak/itemNumbers.hpp"
 #include "bak/gameData.hpp"
 
-#include "bak/save/world.hpp"
 #include "bak/save/containers.hpp"
 #include "bak/save/combat.hpp"
+#include "bak/save/saveOffsets.hpp"
+#include "bak/save/world.hpp"
 
 #include "bak/state/customStateChoice.hpp"
 #include "bak/state/dialog.hpp"
@@ -67,6 +68,15 @@ void GameState::LoadGame(std::string savePath)
     mGDSContainers = LoadShops(mGameData.GetFileBuffer());
     mCombatContainers = LoadCombatInventories(mGameData.GetFileBuffer());
     mTimeExpiringState = LoadTimeExpiringState(mGameData.GetFileBuffer());
+    if (mFixCombatEntityLists)
+    {
+        mLogger.Info() << "Regenerating combat entity lists\n";
+        mCombatEntityLists = RegenerateCombatEntityLists();
+    }
+    else
+    {
+        mCombatEntityLists = LoadCombatEntityLists(mGameData.GetFileBuffer());
+    }
     mCombatWorldLocations = LoadCombatWorldLocations(mGameData.GetFileBuffer());
     mCombatantGridLocations = LoadCombatantGridLocations(mGameData.GetFileBuffer());
     mSpellState = LoadSpells(mGameData.GetFileBuffer());
@@ -696,8 +706,7 @@ void GameState::EvaluateSpecialAction(const SpecialAction& action)
         auto combatIndex = action.mVar1;
         ASSERT(mFindEncounterCallback);
         auto& encounter = mFindEncounterCallback(BAK::CombatIndex{combatIndex});
-        BAK::State::ReactivateCombat(
-            mGameData.GetFileBuffer(), GetZone(), encounter, combatIndex);
+        this->ReactivateCombat(encounter, BAK::CombatIndex{combatIndex});
         break;
     }
     case DeactivateCombat:
@@ -709,17 +718,11 @@ void GameState::EvaluateSpecialAction(const SpecialAction& action)
         BAK::State::DeactivateCombat(mGameData.GetFileBuffer(), GetZone(), encounter, combatIndex);
 
         assert(std::holds_alternative<Encounter::Combat>(encounter.GetEncounter()));
-        // Strictly speaking we should use the combat entity list to go from combatIndex
-        // to combatants, however the combat entity list in the game is incorrect after
-        // entry number 20. Unclear what this next part does since the game seems to 
-        // function correctly event though it modifies the wrong combatant state.
-        for (unsigned combatantIndex = 0; combatantIndex < mCombatContainers.size(); combatantIndex++)
+        auto& cel = GetCombatEntityList(BAK::CombatIndex{combatIndex});
+        for (auto combatantIndex : cel.mCombatants)
         {
-            auto& combatant = mCombatContainers[combatantIndex];
-            if (combatant.GetHeader().GetCombatNumber() != combatIndex) continue;
-            mLogger.Info() << "Deactivate combat, deactivating combatant: " << combatantIndex << "\n";
-
-            auto& cgl = GetCombatantGridLocation(BAK::CombatantIndex{combatantIndex});
+            mLogger.Info() << "Deactivate combat, deactivating combatant: " << combatantIndex.mValue << "\n";
+            auto& cgl = GetCombatantGridLocation(combatantIndex);
             cgl.mUnknown2 |= 2;
         }
 
@@ -1172,6 +1175,7 @@ bool GameState::SaveState()
     BAK::Save(mGameData.mLocation, mGameData.GetFileBuffer());
     BAK::Save(mCombatWorldLocations, mGameData.GetFileBuffer());
     BAK::Save(mCombatantGridLocations, mGameData.GetFileBuffer());
+    BAK::Save(mCombatEntityLists, mGameData.GetFileBuffer());
     return true;
 }
 
@@ -1529,4 +1533,41 @@ CombatantGridLocation& GameState::GetCombatantGridLocation(
 {
     return mCombatantGridLocations[index.mValue];
 }
+
+CombatEntityList& GameState::GetCombatEntityList(
+    CombatIndex index)
+{
+    return mCombatEntityLists[index.mValue];
+}
+
+void GameState::ReactivateCombat(const Encounter::Encounter& encounter, CombatIndex combatIndex)
+{
+    BAK::State::ReactivateCombat(mGameData.GetFileBuffer(), GetZone(), encounter, combatIndex.mValue);
+    auto& cel = GetCombatEntityList(combatIndex);
+    for (const auto& combatantIndex : cel.mCombatants)
+    {
+        auto& cgl = GetCombatantGridLocation(combatantIndex);
+        cgl.mUnknown2 = 1;
+    }
+}
+
+std::vector<CombatEntityList> GameState::RegenerateCombatEntityLists()
+{
+    std::vector<CombatEntityList> mLists{};
+    mLists.reserve(SaveOffsets::sCombatEntityListCount);
+    for (unsigned i = 0; i < SaveOffsets::sCombatEntityListCount; i++)
+    {
+        mLists.emplace_back();
+    }
+
+    for (unsigned combatantIndex = 0; combatantIndex < mCombatContainers.size(); combatantIndex++)
+    {
+        const auto& combatant = mCombatContainers[combatantIndex];
+        const auto combatIndex = combatant.GetHeader().GetCombatNumber();
+        mLists[combatIndex].mCombatants.emplace_back(CombatantIndex{combatantIndex});
+    }
+
+    return mLists;
+}
+
 }

--- a/bak/gameState.hpp
+++ b/bak/gameState.hpp
@@ -186,12 +186,18 @@ public:
         std::uint8_t encounterIndex,
         std::uint8_t combatantRelativeIndex);
     CombatantGridLocation& GetCombatantGridLocation(CombatantIndex);
+    CombatEntityList& GetCombatEntityList(CombatIndex);
+    void ReactivateCombat(const Encounter::Encounter&, CombatIndex);
 
     // Super lame, but BaK uses a global so I will too
     void SetCombatTriggeredFromInteractable(bool value) { mCombatTriggeredFromInteractable = value; }
     bool GetCombatTriggeredFromInteractable() const { return mCombatTriggeredFromInteractable; }
 
+    void SetFixCombatEntityLists(bool value) { mFixCombatEntityLists = value; }
+
 private:
+    std::vector<CombatEntityList> RegenerateCombatEntityLists();
+
     std::optional<CharIndex> mDialogCharacter{};
     CharIndex mActiveCharacter{};
     CharIndex mSkillCheckedCharacter{};
@@ -214,6 +220,7 @@ private:
     unsigned mSkillValue{};
     unsigned mContextVar_753f{};
     bool mCombatTriggeredFromInteractable{};
+    bool mFixCombatEntityLists{false};
 
     std::optional<InventoryItem> mSelectedItem{};
     std::optional<MonsterIndex> mCurrentMonster{};
@@ -223,6 +230,7 @@ private:
     std::vector<GenericContainer> mGDSContainers{};
     std::vector<GenericContainer> mCombatContainers;
     std::vector<TimeExpiringState> mTimeExpiringState{};
+    std::vector<CombatEntityList> mCombatEntityLists{};
     std::vector<CombatWorldLocation> mCombatWorldLocations{};
     std::vector<CombatantGridLocation> mCombatantGridLocations{};
     SpellState mSpellState{};

--- a/bak/save/combat.cpp
+++ b/bak/save/combat.cpp
@@ -42,23 +42,6 @@ std::vector<CombatEntityList> LoadCombatEntityLists(FileBuffer& fb)
     return data;
 }
 
-CombatEntityList LoadCombatEntityList(FileBuffer& fb, CombatIndex index)
-{
-    constexpr unsigned maxCombatants = 7;
-    fb.Seek(SaveOffsets::sCombatEntityListOffset + index.mValue * maxCombatants * 2);
-    auto list = CombatEntityList{};
-
-    for (unsigned i = 0; i < maxCombatants; i++)
-    {
-        auto combatant = fb.GetUint16LE();
-        if (combatant != 0xffff)
-        {
-            list.mCombatants.emplace_back(CombatantIndex{combatant});
-        }
-    }
-    return list;
-}
-
 std::vector<Skills> LoadCombatStats(FileBuffer& fb)
 {
     const auto& logger = Logging::LogState::GetLogger("LoadCombatStats");
@@ -160,6 +143,26 @@ std::vector<Time> LoadCombatClickedTimes(FileBuffer& fb)
         }
     }
     return times;
+}
+
+void Save(const std::vector<CombatEntityList>& cels, FileBuffer& fb)
+{
+    fb.Seek(SaveOffsets::sCombatEntityListOffset);
+    assert(cels.size() == SaveOffsets::sCombatEntityListCount);
+    constexpr unsigned maxCombatants = 7;
+    for (const auto& cel : cels)
+    {
+        unsigned i = 0;
+        for (const auto& combatant : cel.mCombatants)
+        {
+            fb.PutUint16LE(combatant.mValue);
+            i++;
+        }
+        for (; i < maxCombatants; i++)
+        {
+            fb.PutUint16LE(0xffff);
+        }
+    }
 }
 
 void Save(const std::vector<CombatWorldLocation>& cwls, FileBuffer& fb)

--- a/bak/save/combat.hpp
+++ b/bak/save/combat.hpp
@@ -12,7 +12,6 @@ namespace BAK {
 class FileBuffer;
 
 std::vector<CombatEntityList> LoadCombatEntityLists(FileBuffer&);
-CombatEntityList LoadCombatEntityList(FileBuffer&, CombatIndex);
 std::vector<CombatantGridLocation> LoadCombatantGridLocations(FileBuffer&);
 std::vector<CombatWorldLocation> LoadCombatWorldLocations(FileBuffer&);
 std::vector<Skills> LoadCombatStats(FileBuffer&);
@@ -20,5 +19,6 @@ std::vector<Time> LoadCombatClickedTimes(FileBuffer&);
 
 void Save(const std::vector<CombatantGridLocation>&, FileBuffer& fb);
 void Save(const std::vector<CombatWorldLocation>&, FileBuffer&);
+void Save(const std::vector<CombatEntityList>&, FileBuffer&);
 
 }

--- a/bak/state/encounter.cpp
+++ b/bak/state/encounter.cpp
@@ -306,9 +306,7 @@ void SetPostCombatCombatSpecificFlags(
         case 410: [[fallthrough]];
         case 429: [[fallthrough]];
         case 430:
-            gs.Apply(
-                ReactivateCombat,
-                gs.GetZone(), encounter, combatIndex);
+            gs.ReactivateCombat(encounter, BAK::CombatIndex{combatIndex});
             break;
         case 610: [[fallthrough]];
         case 613: [[fallthrough]];
@@ -346,7 +344,6 @@ void ReactivateCombat(
     SetRecentlyEncountered(fb, encounterIndex);
     SetCombatEncounterScoutedState(fb, encounterIndex, false);
     SetCombatEncounterState(fb, combatIndex, false);
-    //ResetCombatantsWorldState(combatIndex);
     SetCombatClickedTime(fb, combatIndex, Time{0});
 }
 

--- a/config.json
+++ b/config.json
@@ -19,7 +19,11 @@
         "EnableBackgroundSounds": true 
     },
     "Game": {
-        "AdvanceTime": true
+        "AdvanceTime": true,
+        // Set this to true to fix the combat entity lists in the game
+        // Note: the lists in the original are bugged, so this fixes it
+        // but if you care about fidelity to the original leave this off
+        "FixCombatEntityLists": false
     },
     "Logging": {
         "LogToFile": true,


### PR DESCRIPTION
Please read Issue #255 for details on why this is a good idea.

Adds flag Game::FixCombatEntityLists defaulting to true which can be used to force the game to rebuild combat entity lists on loading a save.

Please note that this will affect the gameplay experience hence why I have defaulted it to be false.