### PR TITLE
Issue #206 - Make player aware of stat/condition changes

### DIFF
--- a/app/display_save.cpp
+++ b/app/display_save.cpp
@@ -13,6 +13,15 @@ extern "C" {
 #include "com/ostream.hpp"
 #include "com/string.hpp"
 
+#include "bak/state/event.hpp"
+#include "bak/state/offsets.hpp"
+
+#include "bak/save/saveOffsets.hpp"
+
+#include "bak/condition.hpp"
+#include "bak/dialogChoice.hpp"
+#include "bak/types.hpp"
+
 #include "graphics/glm.hpp"
 
 struct Options
@@ -33,12 +42,95 @@ struct Options
     bool combat_stats{};
     bool combat_click{};
     bool combat_lists{};
+    bool event_flags{};
 
     std::string saveFile{};
     std::string character{};
 };
 
 static constexpr int CHARACTER_OPT = 1000;
+static constexpr int EVENT_FLAGS_OPT = 1001;
+
+struct EventFlagRange
+{
+    unsigned start;
+    unsigned end;
+    std::string_view name;
+};
+
+constexpr EventFlagRange sEventFlagRanges[] = {
+    {BAK::State::sEncounterStateOffset,
+        BAK::State::sEncounterStateOffset + BAK::State::sEncounterStateCount - 1,
+        "encounter_unique_state"},
+    {BAK::State::sRecentEncounterOffset,
+        BAK::State::sRecentEncounterOffset + 9,
+        "recent_encounter"},
+    {BAK::State::sCombatScoutedOffset,
+        BAK::State::sCombatScoutedOffset + 9,
+        "combat_scouted"},
+    {BAK::State::sCombatEncounterOffset,
+        BAK::State::sCombatEncounterOffset + BAK::State::sMaxCombatIndex - 1,
+        "combat_encounter"},
+    {BAK::State::sSkillSelectedEventFlag,
+        BAK::State::sSkillSelectedEventFlag + BAK::sMaxCharacters * BAK::State::sMaxSkills - 1,
+        "skill_selected"},
+    {BAK::State::sSkillImprovementEventFlag,
+        BAK::State::sSkillImprovementEventFlag + BAK::sMaxCharacters * BAK::State::sMaxSkills - 1,
+        "skill_improvement"},
+    {BAK::State::sTempleSeenFlag,
+        BAK::State::sTempleSeenFlag + 12,
+        "temple_seen"},
+    {BAK::State::sSpynoteHasBeenRead,
+        BAK::State::sSpynoteHasBeenRead + 13,
+        "spynote_read"},
+    {BAK::State::sQuestFlag_1972,
+        BAK::State::sQuestFlag_1972,
+        "quest_flag"},
+    {BAK::State::sQuestFlag_1979,
+        BAK::State::sQuestFlag_1979,
+        "quest_flag"},
+    {BAK::State::sItemUsedForCharacterAtLeastOnce,
+        BAK::State::sItemUsedForCharacterAtLeastOnce + BAK::sMaxCharacters * BAK::State::sMaxTrackedItems - 1,
+        "item_used"},
+    {BAK::State::sChapterTransitionFlag_1ab1,
+        BAK::State::sChapterTransitionFlag_1ab1,
+        "chapter_transition"},
+    {BAK::State::sConversationOptionInhibitedFlag,
+        BAK::State::sConversationOptionInhibitedFlag + static_cast<unsigned>(BAK::ChoiceMask::Conversation),
+        "conversation_inhibited"},
+    {BAK::State::sDoorFlag,
+        BAK::State::sDoorFlag + 11,
+        "door"},
+    {BAK::State::sLockHasBeenSeenFlag,
+        BAK::State::sLockHasBeenSeenFlag + 7,
+        "lock_seen"},
+    {BAK::State::sConditionStateEventFlag,
+        BAK::State::sConditionStateEventFlag + BAK::sMaxCharacters * BAK::Conditions::sNumConditions - 1,
+        "condition_state"},
+    {BAK::State::sEncounterFlag_1d17,
+        BAK::State::sEncounterFlag_1d17,
+        "encounter_flag"},
+    {BAK::State::sConversationChoiceMarkedFlag,
+        BAK::State::sConversationChoiceMarkedFlag + static_cast<unsigned>(BAK::ChoiceMask::Conversation),
+        "conversation_marked"},
+    {BAK::SaveOffsets::sPantathiansEventFlag,
+        BAK::SaveOffsets::sPantathiansEventFlag,
+        "pantathians"},
+    {BAK::State::sQuestFlag_1f6c,
+        BAK::State::sQuestFlag_1f6c,
+        "quest_flag"},
+    {BAK::State::sQuestFlag_1fbc,
+        BAK::State::sQuestFlag_1fbc,
+        "quest_flag"},
+};
+
+std::string_view GetEventFlagRangeName(unsigned ep)
+{
+    for (const auto& r : sEventFlagRanges)
+        if (ep >= r.start && ep <= r.end)
+            return r.name;
+    return "unknown";
+}
 
 Options Parse(int argc, char** argv)
 {
@@ -61,6 +153,7 @@ Options Parse(int argc, char** argv)
         {"combat_click", no_argument, 0, 'C'},
         {"combat_lists", no_argument, 0, 'l'},
         {"character", required_argument, 0, CHARACTER_OPT},
+        {"event-flags", no_argument, 0, EVENT_FLAGS_OPT},
     };
     int optionIndex = 0;
     int opt;
@@ -83,6 +176,7 @@ Options Parse(int argc, char** argv)
             std::cout << "\t --combat_stats,-S\n";
             std::cout << "\t --combat_click,-C\n";
             std::cout << "\t --combat_lists,-l\n";
+            std::cout << "\t --event-flags Print all event flags as CSV\n";
             std::cout << "\t --character <name> Display character stats matching name\n";
             exit(0);
         }
@@ -149,6 +243,10 @@ Options Parse(int argc, char** argv)
         else if (opt == CHARACTER_OPT)
         {
             values.character = optarg;
+        }
+        else if (opt == EVENT_FLAGS_OPT)
+        {
+            values.event_flags = true;
         }
     }
 
@@ -348,6 +446,18 @@ int main(int argc, char** argv)
             logger.Info() << "  #" << i << " " << times[i] << "\n";
         }
     }
+
+    if (options.event_flags)
+    {
+        auto& fb = gameData.GetFileBuffer();
+        for (unsigned ep = BAK::State::sEncounterStateOffset; ep < BAK::State::sMaxStandardEventPtr; ep++)
+        {
+            logger.Info() << GetEventFlagRangeName(ep) << ","
+                << std::hex << ep << std::dec << ","
+                << (BAK::State::ReadEventBool(fb, ep) ? "true" : "false") << "\n";
+        }
+    }
+
     return 0;
 }
 

--- a/bak/CMakeLists.txt
+++ b/bak/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(bak
     book.hpp book.cpp
     camera.hpp camera.cpp
     camp.hpp camp.cpp
+    checkPartyChanges.hpp checkPartyChanges.cpp
     chapterTransitions.hpp chapterTransitions.cpp
     combat.hpp combat.cpp
     combatModel.hpp combatModel.cpp

--- a/bak/chapterTransitions.cpp
+++ b/bak/chapterTransitions.cpp
@@ -13,6 +13,7 @@
 
 #include "bak/state/event.hpp"
 #include "bak/state/money.hpp"
+#include "bak/state/offsets.hpp"
 
 namespace BAK {
 
@@ -44,9 +45,9 @@ std::optional<BAK::Teleport> TransitionToChapter(Chapter chapter, GameState& gs)
     }
 
     // Set all encounter unique state flags back to false
-    for (unsigned i = 0; i < 0x12c0; i++)
+    for (unsigned i = 0; i < State::sEncounterStateCount; i++)
     {
-        gs.Apply(State::SetEventFlagFalse, 0x190 + i);
+        gs.Apply(State::SetEventFlagFalse, State::sEncounterStateOffset + i);
     }
 
     switch (chapter.mValue)
@@ -63,7 +64,7 @@ std::optional<BAK::Teleport> TransitionToChapter(Chapter chapter, GameState& gs)
         } break;
         case 3:
         {
-            gs.SetEventValue(0x1fbc, 0);
+            gs.SetEventValue(State::sQuestFlag_1fbc, 0);
         } break;
         case 4:
         {
@@ -136,7 +137,7 @@ std::optional<BAK::Teleport> TransitionToChapter(Chapter chapter, GameState& gs)
         } break;
         case 7:
             gs.GetParty().SetMoney(gs.Apply(State::ReadPartyMoney, Chapter{6}));
-            gs.SetEventValue(0x1ab1, 1);
+            gs.SetEventValue(State::sChapterTransitionFlag_1ab1, 1);
             break;
         case 8:
             gs.GetParty().SetMoney(gs.Apply(State::ReadPartyMoney, Chapter{7}));

--- a/bak/checkPartyChanges.cpp
+++ b/bak/checkPartyChanges.cpp
@@ -1,0 +1,139 @@
+#include "bak/checkPartyChanges.hpp"
+
+#include "bak/dialogSources.hpp"
+#include "bak/gameState.hpp"
+#include "bak/party.hpp"
+#include "bak/skills.hpp"
+
+#include <optional>
+
+namespace BAK {
+
+void CachePartyState(PartyChangeCache& cache, const GameState& gs)
+{
+    for (unsigned i = 0; i < sMaxCharacters; i++)
+    {
+        const auto& character = gs.GetParty().GetCharacter(CharIndex{i});
+        cache.mCachedConditions[i] = character.GetConditions();
+        std::uint16_t bitmask = 0;
+        for (unsigned s = 0; s < Skills::sSkills; s++)
+        {
+            if (character.GetSkills().GetSkill(
+                static_cast<SkillType>(s)).mUnseenImprovement)
+                bitmask |= (1 << s);
+        }
+        cache.mCachedUnseenImprovements[i] = bitmask;
+    }
+}
+
+PartyChangeResult CheckPartyChanges(PartyChangeCache& cache, GameState& gameState)
+{
+    bool anyAlive = false;
+    gameState.GetParty().ForEachActiveCharacter([&](const auto& character) {
+        auto nearDeath = character.GetConditions()
+            .GetCondition(BAK::Condition::NearDeath).Get();
+        if (nearDeath == 0)
+        {
+            anyAlive = true;
+        }
+        return Loop::Continue;
+    });
+
+    if (!anyAlive)
+    {
+        return PartyChangeResult{
+            true, DialogSources::mDeathDueToCondition, true};
+    }
+
+    std::optional<SkillType> whichSkill{};
+    std::optional<CharIndex> who{};
+    unsigned howManySkills{};
+    unsigned howManyPeople{};
+
+    gameState.GetParty().ForEachActiveCharacter([&](const auto& character) {
+        const unsigned charIdx = character.GetIndex().mValue;
+        bool skillImproved = false;
+        for (unsigned s = 0; s < Skills::sSkills; s++)
+        {
+            auto skill = static_cast<SkillType>(s);
+            const auto current = character.GetSkills()
+                .GetSkill(skill).mUnseenImprovement;
+            const auto cached = (cache.mCachedUnseenImprovements[charIdx] >> s) & 1;
+            if (current && !cached)
+            {
+                cache.mCachedUnseenImprovements[charIdx] |= (1 << s);
+                if (!whichSkill)
+                {
+                    howManySkills = 1;
+                }
+                else if (skill != *whichSkill)
+                {
+                    howManySkills++;
+                }
+                skillImproved = true;
+                whichSkill = skill;
+            }
+        }
+
+        if (skillImproved)
+        {
+            who = character.GetIndex();
+            howManyPeople++;
+        }
+
+        return Loop::Continue;
+    });
+
+    if (whichSkill)
+    {
+        assert(who);
+        gameState.SetActiveCharacter(*who);
+        gameState.SetImprovedSkill(*whichSkill);
+        Target dialog{};
+        if (howManySkills > 1)
+        {
+            dialog = DialogSources::mSkillImprovedManySkillsOneMember;
+        }
+        else if (howManyPeople > 1)
+        {
+            dialog = DialogSources::mSkillImprovedOneSkillManyMembers;
+        }
+        else
+        {
+            dialog = DialogSources::mSkillImprovedOneSkillOneMember;
+        }
+        return PartyChangeResult{true, dialog};
+    }
+
+    for (unsigned condIdx = 0; condIdx < Conditions::sNumConditions; condIdx++)
+    {
+        const auto cond = static_cast<Condition>(condIdx);
+        const auto notification = DialogSources::GetConditionNotification(cond);
+        if (!notification) continue;
+
+        unsigned howManyAffected = 0;
+
+        gameState.GetParty().ForEachActiveCharacter([&](const auto& character) {
+            const unsigned charIdx = character.GetIndex().mValue;
+            const auto oldVal = cache.mCachedConditions[charIdx].GetCondition(cond).Get();
+            const auto newVal = character.GetConditions().GetCondition(cond).Get();
+            if (oldVal == 0 && newVal != 0)
+            {
+                cache.mCachedConditions[charIdx].SetCondition(cond, newVal);
+                howManyAffected++;
+                gameState.SetActiveCharacter(character.GetIndex());
+            }
+            return Loop::Continue;
+        });
+
+        if (howManyAffected > 0)
+        {
+            gameState.SetDialogContext_7530(howManyAffected > 1 ? 0 : 1);
+            return PartyChangeResult{true, *notification};
+        }
+    }
+
+    return PartyChangeResult{};
+}
+
+}

--- a/bak/checkPartyChanges.hpp
+++ b/bak/checkPartyChanges.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "bak/condition.hpp"
+#include "bak/dialogTarget.hpp"
+#include "bak/types.hpp"
+
+#include <array>
+
+namespace BAK {
+
+class Conditions;
+class GameState;
+
+struct PartyChangeResult {
+    bool mChanged = false;
+    Target mDialog{KeyTarget{0}};
+    bool mDead = false;
+};
+
+struct PartyChangeCache {
+    std::array<Conditions, sMaxCharacters> mCachedConditions{};
+    std::array<std::uint16_t, sMaxCharacters> mCachedUnseenImprovements{};
+};
+
+void CachePartyState(PartyChangeCache& cache, const GameState&);
+PartyChangeResult CheckPartyChanges(PartyChangeCache& cache, GameState&);
+
+}

--- a/bak/combat.cpp
+++ b/bak/combat.cpp
@@ -11,6 +11,18 @@
 
 namespace BAK {
 
+std::string_view ToString(CombatResult r)
+{
+    switch (r)
+    {
+        case CombatResult::None: return "None";
+        case CombatResult::Won: return "Won";
+        case CombatResult::Fled: return "Fled";
+        case CombatResult::Dead: return "Dead";
+    }
+    return "Unknown";
+}
+
 std::string_view ToString(CombatantWorldState s)
 {
     switch (s)
@@ -62,6 +74,29 @@ void LoadP1Dat()
         ss = {};
     }
     Logging::LogDebug(__FUNCTION__) << "Remaining: " << fb.GetBytesLeft() << "\n";
+}
+
+bool IsSpecialBattle(CombatIndex index)
+{
+    switch (index.mValue)
+    {
+        case 151: [[fallthrough]];
+        case 152: [[fallthrough]];
+        case 235: [[fallthrough]];
+        case 245: [[fallthrough]];
+        case 291: [[fallthrough]];
+        case 293: [[fallthrough]];
+        case 335: [[fallthrough]];
+        case 337: [[fallthrough]];
+        case 338: [[fallthrough]];
+        case 375: [[fallthrough]];
+        case 410: [[fallthrough]];
+        case 429: [[fallthrough]];
+        case 430:
+            return true;
+        default:
+            return false;
+    }
 }
 
 }

--- a/bak/combat.hpp
+++ b/bak/combat.hpp
@@ -15,6 +15,8 @@ enum class CombatResult : std::uint8_t
     Dead = 3
 };
 
+std::string_view ToString(CombatResult);
+
 enum class CombatantWorldState : std::uint8_t
 {
     Invisible0,
@@ -66,5 +68,10 @@ public:
 std::ostream& operator<<(std::ostream&, const CombatEntityList&);
 
 void LoadP1Dat();
+
+// Used by combat end to decide whether to use dialog 0x142
+bool IsSpecialBattle(CombatIndex);
+
+static constexpr CombatIndex MakalaCombat{0x221};
     
 }

--- a/bak/condition.cpp
+++ b/bak/condition.cpp
@@ -67,6 +67,7 @@ void Conditions::SetCondition(BAK::Condition cond, std::uint8_t amount)
 void Conditions::AdjustCondition(Skills& skills, BAK::Condition cond, signed amount)
 {
     Logging::LogDebug(__FUNCTION__) << " called with : cond: " << ToString(cond) << " amt: " << amount << "\n";
+    if (amount == 0) return;
     const auto currentValue = GetCondition(cond).Get();
     int newValue = currentValue + amount;
     if (newValue > 100)
@@ -80,22 +81,6 @@ void Conditions::AdjustCondition(Skills& skills, BAK::Condition cond, signed amo
 
     SetCondition(cond, newValue);
 
-    const bool inCombat = false;
-
-    if (cond != Condition::Healing
-        && cond != Condition::Drunk
-        && (cond != Condition::NearDeath || !inCombat))
-    {
-        if (currentValue != 0 && newValue == 0)
-        {
-            //mGameState.SetEventFlag(activeCharIndex * 7 + static_cast<unsigned>(cond) + sConditionBasedFlag, 0);
-        }
-        else if (currentValue == 0 && newValue != 0)
-        {
-            //mGameState.SetEventFlag(activeCharIndex * 7 + static_cast<unsigned>(cond) + sConditionBasedFlag, 1);
-        }
-    }
-    
     if (cond == Condition::NearDeath)
     {
         // Check all character NearDeath

--- a/bak/dialogSources.cpp
+++ b/bak/dialogSources.cpp
@@ -1,5 +1,6 @@
 #include "bak/dialogSources.hpp"
 
+#include "bak/condition.hpp"
 #include "bak/dialog.hpp"
 
 namespace BAK {
@@ -45,7 +46,7 @@ KeyTarget DialogSources::GetTTMDialogKey(unsigned index)
 
 KeyTarget DialogSources::GetChapterStartText(Chapter chapter)
 {
-    return BAK::KeyTarget{mChapterFullMapScreenText + (chapter.mValue - 1)};
+    return KeyTarget{mChapterFullMapScreenText + (chapter.mValue - 1)};
 }
 
 Target DialogSources::GetChoiceResult(KeyTarget dialog, unsigned index)
@@ -56,6 +57,22 @@ Target DialogSources::GetChoiceResult(KeyTarget dialog, unsigned index)
         return a.mMin == index ;} );
     ASSERT(it != choices.end());
     return it->mTarget;
+}
+
+std::optional<Target> DialogSources::GetConditionNotification(Condition c)
+{
+    using enum Condition;
+    switch (c)
+    {
+    case Sick:      return Target{DialogSources::mNotifySick};
+    case Plagued:   return Target{DialogSources::mNotifyPlagued};
+    case Poisoned:  return Target{DialogSources::mNotifyPoisoned};
+    case Starving:  return Target{DialogSources::mNotifyStarving};
+    case NearDeath: return Target{DialogSources::mNotifyNearDeath};
+    case Drunk:     [[fallthrough]];
+    case Healing:   return std::nullopt;
+    }
+    return std::nullopt;
 }
 
 }

--- a/bak/dialogSources.hpp
+++ b/bak/dialogSources.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
+#include "bak/condition.hpp"
 #include "bak/types.hpp"
 #include "bak/dialogTarget.hpp"
 
 #include <functional>
 #include <iomanip>
+#include <optional>
 #include <type_traits>
 #include <variant>
 
@@ -22,6 +24,7 @@ public:
     static KeyTarget GetTTMDialogKey(unsigned index);
     static KeyTarget GetChapterStartText(Chapter chapter);
     static Target GetChoiceResult(KeyTarget dialog, unsigned index);
+    static std::optional<Target> GetConditionNotification(Condition);
     
 
     static constexpr auto mFairyChestKey    = 0x19f0a0;
@@ -169,8 +172,30 @@ public:
 
     /* COMBAT */
     static constexpr auto mWonBattle         = KeyTarget{0x20};
+    static constexpr auto mDied              = KeyTarget{0x21};
     static constexpr auto mRetreatSuccessful = KeyTarget{0x22};
+    static constexpr auto mKilledByTrap      = KeyTarget{0x6b};
+    static constexpr auto mDefeatedOneEnemy  = KeyTarget{0x81};
+    static constexpr auto mEnemyFled         = KeyTarget{0x82};
+    static constexpr auto mSomeoneDied       = KeyTarget{0x83};
+    static constexpr auto mSolvedTrap        = KeyTarget{0x1f};
+    static constexpr auto mWonVersusGhosts   = KeyTarget{0x131};
+    static constexpr auto mWonVersusGhost    = KeyTarget{0x132};
+    static constexpr auto mWonSpecialBattle  = KeyTarget{0x142};
+    static constexpr auto mDeathDueToCondition = KeyTarget{0x145};
+    static constexpr auto mDefeatedMakala    = KeyTarget{0x150};
 
+    /* NOTIFICATIONS */
+    static constexpr auto mSkillImprovedOneSkillManyMembers = KeyTarget{0x200b30};
+    static constexpr auto mSkillImprovedManySkillsManyMembers = KeyTarget{0x200b31};
+    static constexpr auto mSkillImprovedOneSkillOneMember = KeyTarget{0x200b32};
+    static constexpr auto mSkillImprovedManySkillsOneMember = KeyTarget{0x200b33};
+
+    static constexpr auto mNotifySick = KeyTarget{0xf6};
+    static constexpr auto mNotifyPlagued = KeyTarget{0x146};
+    static constexpr auto mNotifyPoisoned = KeyTarget{0xf7};
+    static constexpr auto mNotifyStarving = KeyTarget{0x3f};
+    static constexpr auto mNotifyNearDeath = KeyTarget{0x41};
 };
 
 }

--- a/bak/gameState.cpp
+++ b/bak/gameState.cpp
@@ -15,6 +15,7 @@
 #include "bak/save/world.hpp"
 
 #include "bak/state/customStateChoice.hpp"
+#include "bak/state/offsets.hpp"
 #include "bak/state/dialog.hpp"
 #include "bak/state/event.hpp"
 #include "bak/state/encounter.hpp"
@@ -411,12 +412,13 @@ void GameState::SetDialogTextVariable(unsigned index, unsigned attribute)
         // the skill that increased, either the party's or the
         // selected character
         // mContext_whichSkillIncreased
-        mTextVariableStore.SetTextVariable(index, "skill");
+        mTextVariableStore.SetTextVariable(
+            index, std::string{ToString(mRecentlyImprovedSkill)});
         break;
     case 9:
     case 29:
         // character index is stored in checkSkillValue
-        //mDialogCharacterList[index] =checkedSkillValue;
+        //mDialogCharacterList[index] = checkedSkillValue;
         mTextVariableStore.SetTextVariable(
             index,
             ""); // character at checked skill value
@@ -1059,6 +1061,7 @@ unsigned GameState::ReadEvent(unsigned eventPtr) const
     {
         return GetGameState(GameStateChoice{ActiveStateFlag::DayTime});
     }
+
     return State::ReadEvent(mGameData.GetFileBuffer(), eventPtr);
 }
 
@@ -1112,6 +1115,11 @@ bool GameState::GetMoreThanOneTempleSeen() const
 void GameState::SetDialogContext_7530(unsigned contextValue)
 {
     mContextValue_7530 = contextValue;
+}
+
+void GameState::SetImprovedSkill(SkillType skill)
+{
+    mRecentlyImprovedSkill = skill;
 }
 
 void GameState::SetItemValue(Royals value)
@@ -1246,7 +1254,7 @@ bool GameState::CheckConversationItemAvailable(unsigned conversationItem) const
             return GetEventState(CreateChoice(0xdb9e)) != 0;
         case 44:
             if (!enabled) return false;
-            return ReadEventBool(0x1f6c);
+            return ReadEventBool(State::sQuestFlag_1f6c);
         case 117:
             if (!enabled) return false;
             return GetChapter() == Chapter{6};
@@ -1259,13 +1267,13 @@ bool GameState::CheckConversationItemAvailable(unsigned conversationItem) const
             return false; // (owynsSpells & 0x10) != 0; (Have spell 20 (Unfortunate flux))
         case 132:
             if (!enabled) return false;
-            return HaveNote(0x15) || ReadEventBool(0x1979);
+            return HaveNote(0x15) || ReadEventBool(State::sQuestFlag_1979);
         case 106:
             if (!enabled) return false;
             return true; // owynsOtherSpells & 0x200
         case 164:
             if (!enabled) return false;
-            return ReadEventBool(0x1972);
+            return ReadEventBool(State::sQuestFlag_1972);
         case 76: [[fallthrough]];
         case 148:
             if (!enabled) return false;

--- a/bak/gameState.hpp
+++ b/bak/gameState.hpp
@@ -164,6 +164,8 @@ public:
     bool GetMoreThanOneTempleSeen() const;
 
     void SetDialogContext_7530(unsigned contextValue);
+    void SetImprovedSkill(SkillType skill);
+
     void SetBardReward_754d(unsigned value);
     unsigned GetBardReward_754d();
     void SetItemValue(Royals value);
@@ -216,6 +218,7 @@ private:
     bool mTransitionChapter_7541{};
     unsigned mShopType_7542{};
     unsigned mBardReward_754d{};
+    SkillType mRecentlyImprovedSkill{};
     Royals mItemValue_753e{};
     unsigned mSkillValue{};
     unsigned mContextVar_753f{};

--- a/bak/state/CMakeLists.txt
+++ b/bak/state/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(bakState
+    condition.hpp condition.cpp
     customStateChoice.hpp customStateChoice.cpp
     dialog.hpp dialog.cpp
     door.hpp door.cpp

--- a/bak/state/condition.cpp
+++ b/bak/state/condition.cpp
@@ -1,0 +1,46 @@
+#include "bak/state/condition.hpp"
+
+#include "bak/condition.hpp"
+
+#include "bak/state/event.hpp"
+#include "bak/state/offsets.hpp"
+
+#include "bak/types.hpp"
+
+#include "bak/file/fileBuffer.hpp"
+
+namespace BAK::State {
+
+void SyncConditionEventFlags(
+    FileBuffer& fb,
+    unsigned charIndex,
+    bool inCombat,
+    const Conditions& conditions)
+{
+    for (unsigned i = 0; i < Conditions::sNumConditions; i++)
+    {
+        const auto cond = static_cast<Condition>(i);
+
+        if (cond == Condition::Healing || cond == Condition::Drunk)
+            continue;
+
+        if (cond == Condition::NearDeath && inCombat)
+            continue;
+
+        const auto isActive = conditions.GetCondition(cond).Get() != 0;
+        const auto eventPtr = sConditionStateEventFlag
+            + charIndex * Conditions::sNumConditions
+            + i;
+
+        SetEventFlag(fb, eventPtr, isActive ? 1 : 0);
+    }
+}
+
+bool IsConditionEvent(unsigned eventPtr)
+{
+    constexpr auto sConditionStateEnd = sConditionStateEventFlag
+        + sMaxCharacters * Conditions::sNumConditions;
+    return eventPtr >= sConditionStateEventFlag && eventPtr < sConditionStateEnd;
+}
+
+}

--- a/bak/state/condition.hpp
+++ b/bak/state/condition.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace BAK {
+class FileBuffer;
+class Conditions;
+}
+
+namespace BAK::State {
+
+void SyncConditionEventFlags(
+    FileBuffer& fb,
+    unsigned charIndex,
+    bool inCombat,
+    const Conditions& conditions);
+
+bool IsConditionEvent(unsigned eventPtr);
+}

--- a/bak/state/encounter.cpp
+++ b/bak/state/encounter.cpp
@@ -151,12 +151,11 @@ unsigned CalculateUniqueEncounterStateFlagOffset(
     std::uint8_t tileIndex,
     std::uint8_t encounterIndex) 
 {
-    constexpr auto encounterStateOffset = 0x190;
     constexpr auto maxEncountersPerTile = 0xa;
-    const auto zoneOffset = (zone.mValue - 1) * encounterStateOffset;
+    const auto zoneOffset = (zone.mValue - 1) * sEncounterStateOffset;
     const auto tileOffset = tileIndex * maxEncountersPerTile;
     const auto offset = zoneOffset + tileOffset + encounterIndex;
-    return offset + encounterStateOffset;
+    return offset + sEncounterStateOffset;
 }
 
 bool CheckUniqueEncounterStateFlag(
@@ -191,23 +190,20 @@ void SetUniqueEncounterStateFlag(
 unsigned CalculateCombatEncounterScoutedStateFlag(
     std::uint8_t encounterIndex) 
 {
-    constexpr auto offset = 0x145a;
-    return offset + encounterIndex;
+    return sCombatScoutedOffset + encounterIndex;
 }
 
 unsigned CalculateCombatEncounterStateFlag(
     unsigned combatIndex) 
 {
-    constexpr auto combatEncounterFlag = 0x1464;
-    return combatIndex + combatEncounterFlag;
+    return combatIndex + sCombatEncounterOffset;
 }
 
 bool CheckCombatEncounterStateFlag(
     const GameState& gs,
     unsigned combatIndex) 
 {
-    constexpr auto alwaysTriggeredIndex = 0x3e8;
-    if (combatIndex >= alwaysTriggeredIndex)
+    if (combatIndex >= sMaxCombatIndex)
         return true;
     else
         return gs.ReadEventBool(
@@ -219,8 +215,7 @@ void SetCombatEncounterState(
     unsigned combatIndex,
     bool state)
 {
-    constexpr auto alwaysTriggeredIndex = 0x3e8;
-    if (combatIndex >= alwaysTriggeredIndex)
+    if (combatIndex >= sMaxCombatIndex)
     {
         return;
     }
@@ -243,8 +238,7 @@ unsigned CalculateRecentEncounterStateFlag(
 {
     // Refer readEncounterEventState1450 in IDA
     // These get cleared when we load a new tile
-    constexpr auto offset = 0x1450;
-    return offset + encounterIndex;
+    return sRecentEncounterOffset + encounterIndex;
 }
 
 bool CheckRecentlyEncountered(const GameState& gs, std::uint8_t encounterIndex)
@@ -321,7 +315,7 @@ void SetPostCombatCombatSpecificFlags(
                 && gs.ReadEventBool(0x16cf)
                 && gs.ReadEventBool(0x16d1))
             {
-                gs.SetEventValue(0x1d17, 1);
+                gs.SetEventValue(sEncounterFlag_1d17, 1);
             }
         default:break;
     }

--- a/bak/state/item.cpp
+++ b/bak/state/item.cpp
@@ -9,13 +9,11 @@
 
 namespace BAK::State {
 
-static constexpr auto maxItems = 0x14;
-
 bool ReadItemHasBeenUsed(const GameState& gs, unsigned character, unsigned itemIndex) 
 {
     return gs.ReadEventBool(
         sItemUsedForCharacterAtLeastOnce
-            + ((character * maxItems) + itemIndex));
+            + ((character * sMaxTrackedItems) + itemIndex));
 }
 
 void SetItemHasBeenUsed(FileBuffer& fb, unsigned character, unsigned itemIndex)
@@ -23,7 +21,7 @@ void SetItemHasBeenUsed(FileBuffer& fb, unsigned character, unsigned itemIndex)
     SetEventFlagTrue(
         fb,
         sItemUsedForCharacterAtLeastOnce
-            + ((character * maxItems) + itemIndex));
+            + ((character * sMaxTrackedItems) + itemIndex));
 }
 
 }

--- a/bak/state/offsets.hpp
+++ b/bak/state/offsets.hpp
@@ -25,5 +25,34 @@ static constexpr auto sLockHasBeenSeenFlag = 0x1c5c;
 // Based on disassembly this may be the state of doors (open/closed)
 static constexpr auto sDoorFlag = 0x1b58;
 
+// Encounter state flag range
+static constexpr auto sEncounterStateOffset = 0x190;
+static constexpr auto sEncounterStateCount = 0x12c0;
+
+// Encounter sub-ranges
+static constexpr auto sRecentEncounterOffset = 0x1450;
+static constexpr auto sCombatScoutedOffset = 0x145a;
+static constexpr auto sCombatEncounterOffset = 0x1464;
+
+// Maximum combat index before always-triggered
+static constexpr auto sMaxCombatIndex = 0x3e8;
+
+// Per-character sizes for skill and item tracking
+static constexpr auto sMaxSkills = 0x11;
+static constexpr auto sMaxTrackedItems = 0x14;
+
+// Temple base (moved from temple.cpp local)
+static constexpr auto sTempleSeenFlag = 0x1950;
+
+// Max standard event pointer (one-past-end, derived from buffer layout)
+static constexpr auto sMaxStandardEventPtr = 0x2140;
+
+// Named individual event flags
+static constexpr auto sQuestFlag_1972 = 0x1972;
+static constexpr auto sQuestFlag_1979 = 0x1979;
+static constexpr auto sChapterTransitionFlag_1ab1 = 0x1ab1;
+static constexpr auto sEncounterFlag_1d17 = 0x1d17;
+static constexpr auto sQuestFlag_1f6c = 0x1f6c;
+static constexpr auto sQuestFlag_1fbc = 0x1fbc;
 
 }

--- a/bak/state/skill.cpp
+++ b/bak/state/skill.cpp
@@ -10,42 +10,38 @@ namespace BAK::State {
 
 bool ReadSkillSelected(FileBuffer& fb, unsigned character, unsigned skill) 
 {
-    constexpr auto maxSkills = 0x11;
     return ReadEventBool(
         fb,
         sSkillSelectedEventFlag
-        + (character * maxSkills)
+        + (character * sMaxSkills)
         + skill);
 }
 
 bool ReadSkillUnseenImprovement(FileBuffer& fb, unsigned character, unsigned skill) 
 {
-    constexpr auto maxSkills = 0x11;
     return ReadEventBool(
         fb,
         sSkillImprovementEventFlag
-        + (character * maxSkills)
+        + (character * sMaxSkills)
         + skill);
 }
 
 void SetSkillSelected(FileBuffer& fb, unsigned character, unsigned skill, bool enabled) 
 {
-    constexpr auto maxSkills = 0x11;
     SetEventFlag(
         fb,
         sSkillSelectedEventFlag
-            + (character * maxSkills)
+            + (character * sMaxSkills)
             + skill,
         enabled);
 }
 
 void SetSkillUnseenImprovement(FileBuffer& fb, unsigned character, unsigned skill, bool enabled)
 {
-    constexpr auto maxSkills = 0x11;
     SetEventFlag(
         fb,
         sSkillImprovementEventFlag
-            + (character * maxSkills)
+            + (character * sMaxSkills)
             + skill,
         enabled);
 }
@@ -63,12 +59,11 @@ void SetSelectedSkillPool(FileBuffer& fb, unsigned character, std::uint8_t value
 
 void ClearUnseenImprovements(FileBuffer& fb, unsigned character)
 {
-    constexpr auto maxSkills = 0x11;
-    for (unsigned i = 0; i < maxSkills; i++)
+    for (unsigned i = 0; i < sMaxSkills; i++)
     {
         const auto flag = 
             sSkillImprovementEventFlag
-            + (character * maxSkills)
+            + (character * sMaxSkills)
             + i;
 
         SetEventFlagFalse(fb, flag);

--- a/bak/state/temple.cpp
+++ b/bak/state/temple.cpp
@@ -2,12 +2,11 @@
 
 #include "bak/file/fileBuffer.hpp"
 #include "bak/state/event.hpp"
+#include "bak/state/offsets.hpp"
 
 #include "bak/gameState.hpp"
 
 namespace BAK::State {
-
-static constexpr auto sTempleSeenFlag = 0x1950;
 
 bool ReadTempleSeen(const GameState& gs, unsigned temple)
 {

--- a/com/logger.hpp
+++ b/com/logger.hpp
@@ -217,6 +217,11 @@ public:
         return LogState::Log(LogLevel::Error, mName);
     }
 
+    std::ostream& Fatal() const
+    {
+        return LogState::Log(LogLevel::Fatal, mName);
+    }
+
     std::ostream& Spam() const
     {
         return LogState::Log(LogLevel::Spam, mName);

--- a/com/scopeGuard.hpp
+++ b/com/scopeGuard.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <utility>
+
+template <typename F>
+class ScopeGuard
+{
+public:
+    ScopeGuard(F&& f)
+    :
+        mFunc{std::forward<F>(f)},
+        mActive{true}
+    {}
+
+    ~ScopeGuard()
+    {
+        if (mActive) mFunc();
+    }
+
+    ScopeGuard(const ScopeGuard&) = delete;
+    ScopeGuard& operator=(const ScopeGuard&) = delete;
+    ScopeGuard(ScopeGuard&&) = default;
+    ScopeGuard& operator=(ScopeGuard&&) = default;
+
+    void dismiss() { mActive = false; }
+
+private:
+    F mFunc;
+    bool mActive;
+};
+
+template <typename F>
+ScopeGuard(F&&) -> ScopeGuard<std::decay_t<F>>;

--- a/game/combatEncounterHandler.cpp
+++ b/game/combatEncounterHandler.cpp
@@ -230,6 +230,7 @@ bool CombatEncounterHandler::CheckAndDoCombatEncounter(
     {
         // FIXME: Need to add surprise to EnterCombatScreen
         // recordTimeOfCombat at (combatIndex << 2) + 0x3967
+        mGuiManager.SetCombatSequenceActive();
         mDynamicDialogScene.SetDialogFinished(
             [&](const auto& choice){
                 Logging::LogDebug("Game::CombatEncounterHandler") << "Enter Combat\n";

--- a/game/encounterHandler.cpp
+++ b/game/encounterHandler.cpp
@@ -103,6 +103,20 @@ CombatEncounterHandler& EncounterHandler::GetCombatHandler()
     return mCombatHandler;
 }
 
+void EncounterHandler::StartDialog(BAK::Target dialog, bool clearFinished)
+{
+    if (clearFinished)
+    {
+        mDynamicDialogScene.SetDialogFinished([](auto){});
+    }
+
+    mGuiManager.StartDialog(
+            dialog,
+            false,
+            false,
+            &mDynamicDialogScene);
+}
+
 bool EncounterHandler::DoBlockEncounter(
     const BAK::Encounter::Encounter& encounter,
     const BAK::Encounter::Block& block)
@@ -112,11 +126,7 @@ bool EncounterHandler::DoBlockEncounter(
 
     mLogger.Info() << "DoBlockEncounter for: " << block << "\n";
 
-    mGuiManager.StartDialog(
-            block.mDialog,
-            false,
-            false,
-            &mDynamicDialogScene);
+    StartDialog(block.mDialog);
 
     mCamera.UndoPositionChange();
     mGameState.Apply(
@@ -176,11 +186,7 @@ bool EncounterHandler::DoZoneEncounter(
             mDynamicDialogScene.ResetDialogFinished();
         });
     mLogger.Info() << "Zone transition: " << zone << "\n";
-    mGuiManager.StartDialog(
-        zone.mDialog,
-        false,
-        false,
-        &mDynamicDialogScene);
+    StartDialog(zone.mDialog);
     return true;
 }
 
@@ -234,13 +240,9 @@ bool EncounterHandler::DoGDSEncounter(
                     mGuiManager.EnterGDSScene(
                         gds.mHotspot,
                         [&, exitDialog=gds.mExitDialog](){
-                            mGuiManager.StartDialog(
-                                exitDialog,
-                                false,
-                                false,
-                                &mDynamicDialogScene);
-                            });
-                            mCamera.SetGameLocation(gds.mExitPosition);
+                            StartDialog(exitDialog);
+                        });
+                    mCamera.SetGameLocation(gds.mExitPosition);
                 });
             }
             else
@@ -252,11 +254,7 @@ bool EncounterHandler::DoGDSEncounter(
             mDynamicDialogScene.ResetDialogFinished();
         });
 
-    mGuiManager.StartDialog(
-        gds.mEntryDialog,
-        false,
-        false,
-        &mDynamicDialogScene);
+    StartDialog(gds.mEntryDialog);
     return true;
 }
 

--- a/game/encounterHandler.hpp
+++ b/game/encounterHandler.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
 #include "bak/coordinates.hpp"
+#include "bak/dialogTarget.hpp"
 #include "bak/types.hpp"
+
 #include "com/logger.hpp"
+
 #include "game/combatEncounterHandler.hpp"
 #include "gui/IDialogScene.hpp"
 
@@ -47,6 +50,8 @@ public:
     bool DoEncounter(const BAK::Encounter::Encounter& encounter);
 
     CombatEncounterHandler& GetCombatHandler();
+
+    void StartDialog(BAK::Target, bool clearFinished = false);
 
 private:
     bool DoBlockEncounter(

--- a/game/gameRunner.cpp
+++ b/game/gameRunner.cpp
@@ -387,6 +387,7 @@ void GameRunner::DoGenericContainer(BAK::EntityType et, BAK::GenericContainer& c
 
 void GameRunner::CombatCompleted(BAK::CombatResult result)
 {
+    mLogger.Debug() << __FUNCTION__ << " " << ToString(result) << "\n";
     ASSERT(mActiveEncounter);
     ASSERT(std::holds_alternative<BAK::Encounter::Combat>(mActiveEncounter->GetEncounter()));
     const auto& encounter = *mActiveEncounter;
@@ -395,6 +396,7 @@ void GameRunner::CombatCompleted(BAK::CombatResult result)
     if (result == BAK::CombatResult::Fled)
     {
         // retreat to a combat retreat location based on player entry
+        mEncounterHandler.StartDialog(BAK::DialogSources::mRetreatSuccessful, true);
         return;
     }
     else if (result == BAK::CombatResult::Won)
@@ -417,12 +419,66 @@ void GameRunner::CombatCompleted(BAK::CombatResult result)
             }
 
             const auto& monster = *mCombatModelLoader.mCombatModels[it->mMonster.mValue];
-            const auto deadFrameOffset = monster.GetAnimation(BAK::AnimationType::Dead, BAK::Direction::South).mImageIndices.size() - 1;
+            const auto deadFrameOffset = monster.GetAnimation(
+                BAK::AnimationType::Dead, BAK::Direction::South).mImageIndices.size() - 1;
             it->mCombatantBAKLocation.mState = BAK::CombatantWorldState::Dead;
             it->mAnimationType = BAK::AnimationType::Dead;
             it->mFrame = deadFrameOffset;
             it->Update();
             mClickables.at(entityId).mEntityType = BAK::EntityType::DEAD_COMBATANT;
+        }
+
+        if (BAK::CombatIndex{combat.mCombatIndex} == BAK::MakalaCombat)
+        {
+            mEncounterHandler.StartDialog(BAK::DialogSources::mDefeatedMakala, true);
+            return;
+        }
+
+        unsigned deadCount = 0;
+
+        mGameState.GetParty().ForEachActiveCharacter(
+            [&](const auto& character){
+                if (character.GetConditions()
+                    .GetCondition(BAK::Condition::NearDeath).Get() > 0)
+                {
+                    mGameState.SetDialogTextVariable(0, character.GetIndex().mValue);
+                    deadCount++;
+                }
+                return BAK::Loop::Continue;
+        });
+
+
+        if (deadCount > 0)
+        {
+            mEncounterHandler.StartDialog(BAK::DialogSources::mSomeoneDied, true);
+        }
+        else
+        {
+            if (true) // multiple combatants killed
+            {
+                //if (MonstersWereGhosts)
+                //{
+                //    mEncounterHandler.StartDialog(BAK::DialogSources::mWonVersusGhosts, true);
+                //}
+                if (BAK::IsSpecialBattle(BAK::CombatIndex{combat.mCombatIndex}))
+                {
+                    mEncounterHandler.StartDialog(BAK::DialogSources::mWonSpecialBattle, true);
+                }
+                else
+                {
+                    mEncounterHandler.StartDialog(BAK::DialogSources::mWonBattle, true);
+                }
+            }
+            else // if (OneMonsterInCombat && IsGhost)
+            {
+                mEncounterHandler.StartDialog(BAK::DialogSources::mWonVersusGhost, true);
+            }
+            // else if (OneMonsterInCombat && !IsGhost)
+            // mEncounterHandler.StartDialog(BAK::DialogSources::mDefeatedOneEnemy, true);
+            // else if (NoCombatantsRemaining && IsTrap)
+            // mEncounterHandler.StartDialog(BAK::DialogSources::mSolvedTrap, true);
+            // else if (NoCombatantsRemaining)
+            // mEncounterHandler.StartDialog(BAK::DialogSources::mEnemyFled, true);
         }
     }
 }
@@ -519,7 +575,7 @@ void GameRunner::CheckClickable(unsigned entityId)
 
 void GameRunner::OnTimeDelta(double timeDelta)
 {
-    return;
+    //return;
     mAccumulatedTime += timeDelta;
     if (mAccumulatedTime > .2)
     {

--- a/gui/IGuiManager.hpp
+++ b/gui/IGuiManager.hpp
@@ -56,6 +56,7 @@ public:
     virtual bool IsLockOpened() const = 0;
     virtual bool IsWordLockOpened() const = 0;
 
+    virtual void SetCombatSequenceActive() = 0;
     virtual void AddAnimator(std::unique_ptr<IAnimator>&&) = 0;
     virtual ScreenStack& GetScreenStack() = 0;
 

--- a/gui/camp/campScreen.cpp
+++ b/gui/camp/campScreen.cpp
@@ -154,7 +154,12 @@ void CampScreen::BeginCamp(bool isInn, BAK::ShopStats* shopStats)
 
 void CampScreen::DialogFinished(const std::optional<BAK::ChoiceIndex>& choice)
 {
-    assert(choice);
+    //assert(choice);
+    if (!choice)
+    {
+        Exit();
+        return;
+    }
     if (mGameState.GetEndOfDialogState() == -1 || choice->mValue == BAK::Keywords::sNoIndex)
     {
         Exit();

--- a/gui/combat/combatScreen.cpp
+++ b/gui/combat/combatScreen.cpp
@@ -208,18 +208,12 @@ void CombatScreen::HandleButton(unsigned buttonIndex)
 
 void CombatScreen::ExitCombat()
 {
-    mDialogScene.SetDialogFinished([this](auto choice){
-        mGuiManager.ExitCombat(BAK::CombatResult::Won);
-    });
-    StartDialog(BAK::DialogSources::mWonBattle);
+    mGuiManager.ExitCombat(BAK::CombatResult::Won);
 }
 
 void CombatScreen::Retreat()
 {
-    mDialogScene.SetDialogFinished([this](auto choice){
-        mGuiManager.ExitCombat(BAK::CombatResult::Fled);
-    });
-    StartDialog(BAK::DialogSources::mRetreatSuccessful);
+    mGuiManager.ExitCombat(BAK::CombatResult::Fled);
 }
 
 void CombatScreen::AddChildren()

--- a/gui/guiManager.cpp
+++ b/gui/guiManager.cpp
@@ -1,20 +1,18 @@
 #include "gui/guiManager.hpp"
 
-#include "gui/IDialogScene.hpp"
-#include "gui/cursor.hpp"
-
+#include "bak/checkPartyChanges.hpp"
 #include "bak/gameState.hpp"
 #include "bak/startupFiles.hpp"
+
+#include "gui/IDialogScene.hpp"
+#include "gui/cursor.hpp"
 
 #include "com/cpptrace.hpp"
 #include "com/ostream.hpp"
 
-namespace Gui {
+#include <stdexcept>
 
-GuiScreen::GuiScreen(std::function<void()> finished)
-:
-    mFinished{finished}
-{}
+namespace Gui {
 
 GuiManager::GuiManager(
     Cursor& cursor,
@@ -142,9 +140,10 @@ GuiManager::GuiManager(
     mFadeFunction{},
     mGdsScenes{},
     mDialogScene{nullptr},
-    mGuiScreens{},
+    mOnExitCallbacks{},
     mAnimatorStore{},
     mZoneLoader{nullptr},
+    mPartyDiedScene{[]{}, []{}, [](const auto&){}},
     mLogger{Logging::LogState::GetLogger("Gui::GuiManager")}
 {
     mGdsScenes.reserve(4);
@@ -225,9 +224,9 @@ void GuiManager::PlayCutscene(
         if (mScreenStack.HasChildren())
         {
             mPreviousScreen = mScreenStack.Top();
-            mScreenStack.PopScreen();
+            auto checkMainView = PopScreen();
         }
-        mScreenStack.PushScreen(&mCutscenePlayer);
+        PushScreen(&mCutscenePlayer);
         mCutscenePlayer.Play();
     });
 }
@@ -253,8 +252,8 @@ void GuiManager::EnterMainView()
     mMainView.SetCanSaveBookmark(mMainMenu.CanSaveBookmark());
     mMainView.UpdatePartyMembers(mGameState);
     DoFade(1.0, [this]{
-        mScreenStack.PopScreen();
-        mScreenStack.PushScreen(&mMainView);
+        auto checkMainView = PopScreen();
+        PushScreen(&mMainView);
         if (mOnEnterMainView)
         {
             mOnEnterMainView();
@@ -268,9 +267,9 @@ void GuiManager::EnterMainMenu(bool gameRunning)
     DoFade(1.0, [this, gameRunning]{
         if (gameRunning)
         {
-            mScreenStack.PopScreen();
+            auto checkMainView = PopScreen();
         }
-        mScreenStack.PushScreen(&mMainMenu);
+        PushScreen(&mMainMenu);
         mMainMenu.EnterMainMenu(gameRunning);
     });
 }
@@ -323,18 +322,17 @@ void GuiManager::EnterGDSScene(
     if (song != 0)
     {
         AudioA::GetAudioManager().ChangeMusicTrack(AudioA::MusicIndex{song});
-        mGuiScreens.push(GuiScreen{
-            [fin = std::move(finished)](){
+        mOnExitCallbacks.push([fin = std::move(finished)](){
                 AudioA::GetAudioManager().PopTrack();
                 std::invoke(fin);
-        }});
+        });
     }
     else
     {
-        mGuiScreens.push(finished);
+        mOnExitCallbacks.push(std::move(finished));
     }
 
-    mScreenStack.PushScreen(mGdsScenes.back().get());
+    PushScreen(mGdsScenes.back().get());
     mGdsScenes.back()->EnterGDSScene();
 }
 
@@ -348,13 +346,10 @@ void GuiManager::RemoveGDSScene(bool runFinished)
 {
     ASSERT(!mGdsScenes.empty());
     mLogger.Debug() << __FUNCTION__ << " Widgets: " << mScreenStack.GetChildren() << "\n";
-    mScreenStack.PopScreen();
+    auto checkMainView = PopScreen();
     mCursor.PopCursor();
     mCursor.PopCursor();
-    if (runFinished)
-        PopAndRunGuiScreen();
-    else
-        PopGuiScreen();
+    PopOnExitCallback(runFinished ? OnExit::Run : OnExit::Discard);
     mLogger.Debug() << "Removed GDS Scene: " << mGdsScenes.back() << std::endl;
     mGdsScenes.pop_back();
 }
@@ -365,12 +360,17 @@ void GuiManager::StartDialog(
     bool drawWorldFrame,
     IDialogScene* scene)
 {
+    mLogger.Debug() << "StartDialog(" << dialog << ")\n";
+    if (mScreenStack.Top() == &mDialogRunner)
+    {
+        mLogger.Fatal() << "Tried to start a dialog from GuiManager but one is already running" << std::endl;
+        throw std::runtime_error("failure");
+    }
     mCursor.PushCursor(0);
     mDialogRunner.SetInWorldView(InMainView() || drawWorldFrame);
-    mGuiScreens.push(GuiScreen{[](){
-    }});
+    mOnExitCallbacks.push(nullptr);
 
-    mScreenStack.PushScreen(&mDialogRunner);
+    PushScreen(&mDialogRunner);
     mDialogScene = scene;
     mDialogRunner.SetDialogScene(scene);
     mDialogRunner.BeginDialog(dialog, isTooltip);
@@ -379,8 +379,8 @@ void GuiManager::StartDialog(
 void GuiManager::DialogFinished(const std::optional<BAK::ChoiceIndex>& choice)
 {
     ASSERT(mDialogScene);
-    PopAndRunGuiScreen();
-    mScreenStack.PopScreen(); // Dialog runner
+    PopOnExitCallback(OnExit::Run);
+    auto checkMainView = PopScreen(); // Dialog runner
     mCursor.PopCursor();
 
     mLogger.Debug() << "Finished dialog with choice : " << choice << "\n";
@@ -455,24 +455,24 @@ void GuiManager::ShowCharacterPortrait(BAK::ActiveCharIndex character)
     DoFade(.8, [this, character]{
         mInfoScreen.SetSelectedCharacter(character);
         mInfoScreen.UpdateCharacter();
-        mScreenStack.PushScreen(&mInfoScreen);
+        PushScreen(&mInfoScreen);
     });
 }
 
 void GuiManager::ExitSimpleScreen()
 {
-    mScreenStack.PopScreen();
+    auto checkMainView = PopScreen();
 }
 
 void GuiManager::ShowInventory(BAK::ActiveCharIndex character)
 {
     DoFade(.8, [this, character]{
         mCursor.PushCursor(0);
-        mGuiScreens.push(GuiScreen{[](){}});
+        mOnExitCallbacks.push(nullptr);
         mInventoryScreen.SetSelectionMode(false, nullptr);
 
         mInventoryScreen.SetSelectedCharacter(character);
-        mScreenStack.PushScreen(&mInventoryScreen);
+        PushScreen(&mInventoryScreen);
     });
 }
 
@@ -482,7 +482,7 @@ void GuiManager::ShowContainer(BAK::GenericContainer* container, BAK::EntityType
     ASSERT(container);
     ASSERT(container->GetInventory().GetCapacity() > 0);
 
-    mGuiScreens.push(GuiScreen{[this, container, containerType](){
+    mOnExitCallbacks.push([this, container, containerType](){
         mLogger.Debug() << "ExitContainer guiScreen hasDiag: " << container->HasDialog() << " et: " << std::to_underlying(containerType) << "\n";
         mInventoryScreen.ClearContainer();
         if (container->HasDialog())
@@ -497,12 +497,12 @@ void GuiManager::ShowContainer(BAK::GenericContainer* container, BAK::EntityType
         {
             mGameState.SetEventValue(container->GetEncounter().mSetEventFlag, 1);
         }
-    }});
+    });
 
     mInventoryScreen.SetSelectionMode(false, nullptr);
     mInventoryScreen.SetContainer(container, containerType);
     mLogger.Debug() << __FUNCTION__ << " Pushing inv\n";
-    mScreenStack.PushScreen(&mInventoryScreen);
+    PushScreen(&mInventoryScreen);
 }
 
 void GuiManager::EnterCombat(std::function<void(BAK::CombatResult)>&& finished)
@@ -511,14 +511,14 @@ void GuiManager::EnterCombat(std::function<void(BAK::CombatResult)>&& finished)
     DoFade(.8, [this]{
         mCursor.PushCursor(0);
         mCombatScreen.SetSelectedCharacter(BAK::ActiveCharIndex{0});
-        mScreenStack.PushScreen(&mCombatScreen);
+        PushScreen(&mCombatScreen);
     });
 }
 
 void GuiManager::ExitCombat(BAK::CombatResult combatResult)
 {
     mCursor.PopCursor();
-    mScreenStack.PopScreen();
+    auto checkMainView = PopScreen();
     ASSERT(mCombatFinishedCallback);
     mCombatFinishedCallback(combatResult);
     mCombatFinishedCallback = nullptr;
@@ -528,14 +528,14 @@ void GuiManager::SelectItem(std::function<void(std::optional<std::pair<BAK::Acti
 {
     mCursor.PushCursor(0);
 
-    mGuiScreens.push(GuiScreen{[&, selected=itemSelected]() mutable {
+    mOnExitCallbacks.push([&, selected=itemSelected]() mutable {
             mLogger.Debug() << __FUNCTION__ << " SelectItem\n";
             selected(std::nullopt);
-    }});
+    });
 
     mInventoryScreen.SetSelectionMode(true, std::move(itemSelected));
     mLogger.Debug() << __FUNCTION__ << " Pushing select item\n";
-    mScreenStack.PushScreen(&mInventoryScreen);
+    PushScreen(&mInventoryScreen);
 }
 
 void GuiManager::ExitInventory()
@@ -544,8 +544,8 @@ void GuiManager::ExitInventory()
 
     auto exitInventory = [&]{
         mCursor.PopCursor();
-        mScreenStack.PopScreen();
-        PopAndRunGuiScreen();
+        auto checkMainView = PopScreen();
+        PopOnExitCallback(OnExit::Run);
     };
 
     if (mGameState.GetTransitionChapter_7541())
@@ -577,31 +577,31 @@ void GuiManager::ShowLock(
     if (container->GetLock().IsFairyChest())
     {
         mMoredhelScreen.SetContainer(container);
-        mScreenStack.PushScreen(&mMoredhelScreen);
+        PushScreen(&mMoredhelScreen);
         AudioA::GetAudioManager().ChangeMusicTrack(AudioA::PUZZLE_CHEST_THEME);
-        mGuiScreens.push(GuiScreen{
+        mOnExitCallbacks.push(
             [fin = std::move(finished)](){
                 AudioA::GetAudioManager().PopTrack();
                 std::invoke(fin);
-        }});
+        });
     }
     else
     {
         mLockScreen.SetContainer(container);
-        mScreenStack.PushScreen(&mLockScreen);
-        mGuiScreens.push(finished);
+        PushScreen(&mLockScreen);
+        mOnExitCallbacks.push(std::move(finished));
     }
 }
 
 void GuiManager::ShowCamp(bool isInn, BAK::ShopStats* inn)
 {
     assert(!isInn || inn);
-    mGuiScreens.push(GuiScreen{[this]{
+    mOnExitCallbacks.push([this]{
         mCursor.PopCursor();
-    }});
+    });
 
     DoFade(.8, [this, isInn, inn]{
-        mScreenStack.PushScreen(&mCampScreen);
+        PushScreen(&mCampScreen);
         mCursor.PushCursor(0);
         mCampScreen.BeginCamp(isInn, inn);
     });
@@ -609,12 +609,12 @@ void GuiManager::ShowCamp(bool isInn, BAK::ShopStats* inn)
 
 void GuiManager::ShowCast(bool inCombat)
 {
-    mGuiScreens.push(GuiScreen{[this]{
+    mOnExitCallbacks.push([this]{
         mCursor.PopCursor();
-    }});
+    });
 
     DoFade(.8, [this, inCombat]{
-        mScreenStack.PushScreen(&mCastScreen);
+        PushScreen(&mCastScreen);
         mCursor.PushCursor(0);
         mCastScreen.BeginCast(inCombat);
     });
@@ -625,16 +625,16 @@ void GuiManager::ShowFullMap()
     mFullMap.UpdateLocation();
     mFullMap.DisplayMapMode();
     DoFade(1.0, [this]{
-        mScreenStack.PushScreen(&mFullMap);
+        PushScreen(&mFullMap);
     });
 }
 
 void GuiManager::ShowGameStartMap()
 {
     DoFade(1.0, [this]{
-        mScreenStack.PopScreen();
+        auto checkMainView = PopScreen();
         mFullMap.DisplayGameStartMode(mGameState.GetChapter(), mGameState.GetMapLocation(), mDebugDisableFades);
-        mScreenStack.PushScreen(&mFullMap);
+        PushScreen(&mFullMap);
     });
 }
 
@@ -645,7 +645,7 @@ void GuiManager::ShowCureScreen(
 {
     DoFade(.8, [this, templeNumber, cureFactor, finished=std::move(finished)]() mutable {
         mCureScreen.EnterScreen(templeNumber, cureFactor, std::move(finished));
-        mScreenStack.PushScreen(&mCureScreen);
+        PushScreen(&mCureScreen);
     });
 }
 
@@ -654,15 +654,15 @@ void GuiManager::ShowTeleport(unsigned sourceTemple, BAK::ShopStats* temple)
     mTeleportScreen.SetSourceTemple(sourceTemple, temple);
     DoFade(.8, [this]{
         mCursor.PopCursor();
-        mScreenStack.PushScreen(&mTeleportScreen);
+        PushScreen(&mTeleportScreen);
     });
 }
 
 void GuiManager::ExitLock()
 {
     mCursor.PopCursor();
-    mScreenStack.PopScreen();
-    PopAndRunGuiScreen();
+    auto checkMainView = PopScreen();
+    PopOnExitCallback(OnExit::Run);
 }
 
 bool GuiManager::IsLockOpened() const
@@ -675,18 +675,88 @@ bool GuiManager::IsWordLockOpened() const
     return mMoredhelScreen.IsUnlocked();
 }
 
-void GuiManager::PopGuiScreen()
+void GuiManager::PopOnExitCallback(OnExit action)
 {
-    mGuiScreens.pop();
+    // Avoids reentrancy by ensuring this gui screen is not
+    // in the stack when it is executed.
+    auto callback = std::move(mOnExitCallbacks.top());
+    mOnExitCallbacks.pop();
+    if (action == OnExit::Run && callback)
+        callback();
 }
 
-void GuiManager::PopAndRunGuiScreen()
+void GuiManager::PushScreen(Widget* screen)
 {
-    // Avoids reentrancy issue by ensuring this gui screen is not
-    // in the stack when it is executed.
-    auto guiScreen = mGuiScreens.top();
-    mGuiScreens.pop();
-    guiScreen.mFinished();
+    mLogger.Info() << "PushScreen: " << screen << " "
+        << std::boolalpha << " AmInMainView: "
+        << mAmInMainView << " InMainView() " << InMainView() << "\n";
+    if (mAmInMainView && InMainView())
+    {
+        mAmInMainView = false;
+        CacheState();
+    }
+    mScreenStack.PushScreen(screen);
+}
+
+ScopeGuard<std::function<void()>> GuiManager::PopScreen()
+{
+    mLogger.Info() << "Pop screen. InMainView? " << std::boolalpha << InMainView() << "\n";
+    mScreenStack.PopScreen();
+    return ScopeGuard<std::function<void()>>([this]{
+        mLogger.Info() << "Scope guard fired after pop screen. InMainView? " << std::boolalpha << InMainView() << "\n";
+        if (InMainView() && !mAmInMainView)
+        {
+            if (std::exchange(mCombatSequenceActive, false))
+            {
+                // Defer stat/condition checking until after combat
+                return;
+            }
+            else
+            {
+                mAmInMainView = !NotifyPartyChanges();
+            }
+        };
+    });
+}
+
+void GuiManager::CacheState()
+{
+    BAK::CachePartyState(mPartyChangeCache, mGameState);
+}
+
+bool GuiManager::NotifyPartyChanges()
+{
+    auto result = BAK::CheckPartyChanges(
+        mPartyChangeCache, mGameState);
+    if (result.mChanged)
+    {
+        if (result.mDead)
+        {
+            PartyDied(result.mDialog);
+        }
+        else
+        {
+            StartDialog(
+                result.mDialog,
+                false,
+                true,
+                &mNullDialogScene);
+        }
+    }
+    return result.mChanged;
+}
+
+void GuiManager::PartyDied(BAK::Target dialog)
+{
+    mPartyDiedScene.SetDialogFinished(
+        [this](const auto&){
+            EnterMainMenu(false);
+        });
+    StartDialog(
+        dialog,
+        false,
+        true,
+        &mPartyDiedScene);
 }
 
 void GuiManager::FadeInDone()

--- a/gui/guiManager.hpp
+++ b/gui/guiManager.hpp
@@ -8,6 +8,8 @@
 #include "bak/entityType.hpp"
 #include "bak/saveManager.hpp"
 
+#include "com/scopeGuard.hpp"
+
 #include "gui/IGuiManager.hpp"
 
 #include "gui/actors.hpp"
@@ -31,9 +33,16 @@
 #include "gui/teleportScreen.hpp"
 #include "gui/cutscenePlayer.hpp"
 #include "gui/core/widget.hpp"
+#include "gui/IDialogScene.hpp"
+
+#include "bak/checkPartyChanges.hpp"
+#include "bak/condition.hpp"
+#include "bak/skills.hpp"
+#include "bak/types.hpp"
 
 #include <glm/glm.hpp>
 
+#include <array>
 #include <functional>
 #include <utility>
 
@@ -43,15 +52,10 @@ class GameState;
 
 namespace Gui {
 
+enum class OnExit { Discard, Run };
+
 class IDialogScene;
 class Cursor;
-
-class GuiScreen
-{
-public:
-    GuiScreen(std::function<void()> finished);
-    std::function<void()> mFinished;
-};
 
 class GuiManager final : public Widget, public IGuiManager
 {
@@ -80,6 +84,7 @@ public:
     bool InCombatView() const override;
     void EnterMainView() override;
     void EnterMainMenu(bool gameRunning) override;
+    void PartyDied(BAK::Target dialog);
 
     void TeleportToGDS(
         const BAK::HotspotRef& hotspot);
@@ -129,9 +134,14 @@ public:
     bool IsLockOpened() const override;
     bool IsWordLockOpened() const override;
 
-    void PopGuiScreen();
-    void PopAndRunGuiScreen();
+    void PushScreen(Widget* screen);
+    ScopeGuard<std::function<void()>> PopScreen();
+
+    void SetCombatSequenceActive() override { mCombatSequenceActive = true; }
+    void PopOnExitCallback(OnExit action);
 private:
+    void CacheState();
+    bool NotifyPartyChanges();
     void FadeInDone();
     void FadeOutDone();
 
@@ -174,13 +184,20 @@ private:
     std::vector<std::unique_ptr<GDSScene>> mGdsScenes;
 
     IDialogScene* mDialogScene;
-    std::stack<GuiScreen> mGuiScreens;
+    std::stack<std::function<void()>> mOnExitCallbacks;
 
     AnimatorStore mAnimatorStore;
     BAK::IZoneLoader* mZoneLoader;
     Widget* mPreviousScreen{nullptr};
 
     BAK::Encounter::TeleportFactory mTeleportFactory{};
+
+    bool mAmInMainView{false};
+    bool mCombatSequenceActive{false};
+
+    NullDialogScene mNullDialogScene{};
+    DynamicDialogScene mPartyDiedScene;
+    BAK::PartyChangeCache mPartyChangeCache{};
 
     const Logging::Logger& mLogger;
 };

--- a/gui/screenStack.cpp
+++ b/gui/screenStack.cpp
@@ -40,6 +40,11 @@ bool ScreenStack::OnMouseEvent(const MouseEvent& event)
 void ScreenStack::PushScreen(Widget* widget)
 {
     mLogger.Debug() << "Widgets: " << GetChildren() << " Pushed widget " << std::hex << widget << std::dec << "\n";
+    if (std::find(GetChildren().begin(), GetChildren().end(), widget) != GetChildren().end())
+    {
+        mLogger.Error() << "Current stack: " << GetChildren() << "\n";
+        mLogger.Error() << "Tried to push a widget to the stack that is already in the stack: " << widget << std::endl;
+    }
     AddChildBack(widget);
 }
 


### PR DESCRIPTION
Wire up the condition event flag setting. Rather than wiring condition setting through to game state (global var approach), as the original game did, I cache the condition and skill state before leaving the main view, and check them again when re-entering the main view. This has the same effect as in the original game.

Required a little bit of refactoring to make this work nicely but I think the final solution is quite neat. This correctly handles simultaneous stat and multiple condition changes as the original game does.

I've also added the death condition when condition causes death (e.g. trapped box, running out of food, etc.).

Still outstanding is checking condition changes in the camp screen, and clearing the near death condition flag when near death due to combat, as near death will be shown when exiting the combat.