### PR TITLE
Use _WIN32 instead of _MSC_VER for MSVC-specific code paths

### DIFF
--- a/com/logger.hpp
+++ b/com/logger.hpp
@@ -146,7 +146,7 @@ private:
             const auto t = std::chrono::system_clock::now();
             const auto time = std::chrono::system_clock::to_time_t(t);
             auto gmt_time = tm{};
-#ifdef _MSC_VER
+#if defined(_WIN32)
             gmtime_s(&gmt_time , &time);
 #else
             gmtime_r(&time, &gmt_time);

--- a/com/path.cpp
+++ b/com/path.cpp
@@ -3,11 +3,11 @@
 
 std::string GetHomeDirectory()
 {
-#ifdef _MSC_VER
+#if defined(_WIN32)
     constexpr auto homeVar = "APPDATA";
 #else
     constexpr auto homeVar = "HOME";
-#endif 
+#endif
     auto* home = getenv(homeVar);
 
     if (home == nullptr)


### PR DESCRIPTION
Two spots gate MSVC-only behaviour behind `_MSC_VER`, which excludes other Windows compilers (notably mingw-w64). On a mingw build both fall through to the POSIX branch:

- `com/logger.hpp` — calls POSIX `gmtime_r` (absent on Windows) instead of `gmtime_s`.
- `com/path.cpp` — uses the `HOME` env var instead of `APPDATA`; `HOME` is unset on stock Windows, so `getenv` returns null and the `Paths` singleton throws at startup (before any window or log exists).

Switch both to `#if defined(_WIN32)` so any Windows toolchain takes the Windows path. Builds clean on Linux/gcc and mingw-w64.
