### PR TITLE
mingw-w64 portability: _WIN32 intrinsics + clear spurious eofbit on file open

### DIFF
--- a/bak/file/util.cpp
+++ b/bak/file/util.cpp
@@ -19,7 +19,10 @@ FileBuffer CreateFileBuffer(const std::string& fileName)
     std::ifstream in{};
     in.open(fileName, std::ios::in | std::ios::binary);
 
-    if (!in.good())
+    // Check is_open() rather than good(): on mingw-w64, a successful open() leaves eofbit set
+    // (so good() == false even though the file is open). Clear the spurious bit and the stream
+    // reads normally (byte-identical to a stdio read).
+    if (!in.is_open())
     {
         std::cerr << "Failed to open file: " << fileName<< std::endl;
         std::stringstream ss{};
@@ -27,6 +30,7 @@ FileBuffer CreateFileBuffer(const std::string& fileName)
         Logging::LogFatal("FileBuffer") << ss.str() << std::endl;
         throw std::runtime_error(ss.str());
     }
+    in.clear();
 
     FileBuffer fb{GetStreamSize(in)};
     fb.Load(in);

--- a/com/logger.hpp
+++ b/com/logger.hpp
@@ -146,7 +146,7 @@ private:
             const auto t = std::chrono::system_clock::now();
             const auto time = std::chrono::system_clock::to_time_t(t);
             auto gmt_time = tm{};
-#ifdef _MSC_VER
+#if defined(_WIN32)
             gmtime_s(&gmt_time , &time);
 #else
             gmtime_r(&time, &gmt_time);

--- a/com/path.cpp
+++ b/com/path.cpp
@@ -3,11 +3,11 @@
 
 std::string GetHomeDirectory()
 {
-#ifdef _MSC_VER
+#if defined(_WIN32)
     constexpr auto homeVar = "APPDATA";
 #else
     constexpr auto homeVar = "HOME";
-#endif 
+#endif
     auto* home = getenv(homeVar);
 
     if (home == nullptr)


### PR DESCRIPTION
Two small mingw-w64 portability fixes (folds in #282 as requested).

**1. Use `_WIN32` instead of `_MSC_VER` for MSVC-specific code paths**
- `com/logger.hpp` — POSIX `gmtime_r` isn't available on Windows; mingw needs `gmtime_s`.
- `com/path.cpp` — `HOME` is unset on stock Windows; mingw needs `APPDATA`, else the `Paths` singleton throws at startup.

**2. Fix data-file loading on mingw-w64**
On the mingw-w64 build, `std::ifstream::open()` succeeds (`is_open() == true`) but leaves **eofbit** set, so `good()` returns false even though the file opened. `CreateFileBuffer`'s `if (!in.good())` check read that as a failure and threw `OpenError` for every data file. Fix: check `is_open()` and `clear()` the spurious eofbit — the existing read path is unchanged and returns byte-identical data to a stdio read.

_(Earlier revisions of this PR switched to stdio with a locale-based explanation. That was a misdiagnosis — see the comment below for how it was actually tracked down.)_
