### PR TITLE
Issue #255 - Remove "FixCombatEntityLists" functionality

### DIFF
--- a/app/config.cpp
+++ b/app/config.cpp
@@ -87,7 +87,6 @@ Game LoadGame(const nlohmann::json& config)
     {
         const auto& c = config["Game"];
         game.mAdvanceTime = c.value("AdvanceTime", true);
-        game.mFixCombatEntityLists = c.value("FixCombatEntityLists", false);
         game.mCombatSpeed = c.value("CombatSpeed", 1.0);
     }
     return game;

--- a/app/config.hpp
+++ b/app/config.hpp
@@ -46,7 +46,6 @@ struct Audio
 struct Game
 {
     bool mAdvanceTime{true};
-    bool mFixCombatEntityLists{false};
     double mCombatSpeed{1.0};
 };
 

--- a/app/display_save.cpp
+++ b/app/display_save.cpp
@@ -456,18 +456,18 @@ int main(int argc, char** argv)
         }
     }
 
-    if (options.combatant_characters)
-    {
-        logger.Info() << "Combatant Characters:\n";
-        auto& fb = gameData.GetFileBuffer();
-        auto combatInventories = LoadCombatInventories(fb);
-        for (unsigned i = 0; i < BAK::SaveOffsets::sCombatStatsCount; i++)
-        {
-            auto character = LoadCombatant(
-                BAK::CombatantIndex{i}, fb, combatInventories[i]);
-            logger.Info() << character << "\n";
-        }
-    }
+    //if (options.combatant_characters)
+    //{
+    //    logger.Info() << "Combatant Characters:\n";
+    //    auto& fb = gameData.GetFileBuffer();
+    //    auto combatInventories = LoadCombatInventories(fb);
+    //    for (unsigned i = 0; i < BAK::SaveOffsets::sCombatStatsCount; i++)
+    //    {
+    //        auto character = LoadCombatant(
+    //            BAK::CombatantIndex{i}, fb, combatInventories[i]);
+    //        logger.Info() << character << "\n";
+    //    }
+    //}
 
     if (options.event_flags)
     {

--- a/app/main3d.cpp
+++ b/app/main3d.cpp
@@ -265,7 +265,6 @@ int main(int argc, char** argv)
         height / guiScalar};
         
     auto gameState = BAK::GameState{};
-    gameState.SetFixCombatEntityLists(config.mGame.mFixCombatEntityLists);
 
     auto guiManager = Gui::GuiManager{
         root.GetCursor(),

--- a/bak/combat/combat.cpp
+++ b/bak/combat/combat.cpp
@@ -62,6 +62,13 @@ std::ostream& operator<<(std::ostream& os, const CombatantGridLocation& cgl)
     return os;
 }
 
+std::ostream& operator<<(std::ostream& os, const CombatRelInfo & cri)
+{
+    os << "CombatRelInfo{ Combat# " << cri.mCombatIndex
+        << " RelEnemy #" << cri.mCombatantRelativeIndex << "}";
+    return os;
+}
+
 std::ostream& operator<<(std::ostream& os, const CombatEntityList& cel)
 {
     os << "CombatEntityList{" << cel.mCombatants << "}";

--- a/bak/combat/combat.hpp
+++ b/bak/combat/combat.hpp
@@ -61,11 +61,14 @@ public:
 
 std::ostream& operator<<(std::ostream&, const CombatantGridLocation&);
 
-/* The combat entity lists in the game (at least versions I have
- * access to) seem to be incorrect. They begin to differ from the
- * combatant inventories (which I take to be the truth) at entry 20.
- * Refer to notes/combat_entity_list.txt for more info.
- */
+struct CombatRelInfo
+{
+    CombatIndex mCombatIndex;
+    unsigned mCombatantRelativeIndex;
+};
+
+std::ostream& operator<<(std::ostream&, const CombatRelInfo&);
+
 class CombatEntityList
 {
 public:

--- a/bak/gameState.cpp
+++ b/bak/gameState.cpp
@@ -70,28 +70,26 @@ void GameState::LoadGame(std::string savePath)
     mGDSContainers = LoadShops(mGameData.GetFileBuffer());
     mCombatContainers = LoadCombatInventories(mGameData.GetFileBuffer());
     mTimeExpiringState = LoadTimeExpiringState(mGameData.GetFileBuffer());
-    // There's too many inconsistencies in the game for this to work.
-    // e.g. The combatant associated with Baby Irisa grave is 1699 according
-    // to it's inventory, but there is no CGL associated with 1699.
-    if (mFixCombatEntityLists)
-    {
-        mLogger.Info() << "Regenerating combat entity lists\n";
-        mCombatEntityLists = RegenerateCombatEntityLists();
-    }
-    else
-    {
-        mCombatEntityLists = LoadCombatEntityLists(mGameData.GetFileBuffer());
-    }
+    mCombatEntityLists = LoadCombatEntityLists(mGameData.GetFileBuffer());
     mCombatWorldLocations = LoadCombatWorldLocations(mGameData.GetFileBuffer());
     mCombatantGridLocations = LoadCombatantGridLocations(mGameData.GetFileBuffer());
     mCombatCharacters.clear();
     mCombatCharacters.reserve(SaveOffsets::sCombatStatsCount);
     for (unsigned i = 0; i < SaveOffsets::sCombatStatsCount; i++)
     {
+        auto combatRelInfo = GetCombatRelInfo(CombatantIndex{i});
+        assert(combatRelInfo);
+        auto* container = GetCombatContainer(*combatRelInfo);
+        if (!container)
+        {
+            mLogger.Warn() << "No combat container for entity #" << i
+                << " " << combatRelInfo << "\n";
+        }
+        auto* inventory = container ? (&container->GetInventory()) : nullptr;
         mCombatCharacters.emplace_back(LoadCombatant(
             CombatantIndex{i},
             mGameData.GetFileBuffer(),
-            mCombatContainers[i]));
+            inventory));
     }
     mSpellState = LoadSpells(mGameData.GetFileBuffer());
 }
@@ -1198,7 +1196,7 @@ bool GameState::SaveState()
     BAK::Save(mGameData.mLocation, mGameData.GetFileBuffer());
     BAK::Save(mCombatWorldLocations, mGameData.GetFileBuffer());
     BAK::Save(mCombatantGridLocations, mGameData.GetFileBuffer());
-    BAK::Save(mCombatEntityLists, mGameData.GetFileBuffer());
+    //BAK::Save(mCombatEntityLists, mGameData.GetFileBuffer());
     BAK::Save(mCombatCharacters, mGameData.GetFileBuffer());
 
     return true;
@@ -1571,6 +1569,39 @@ CombatEntityList& GameState::GetCombatEntityList(
     CombatIndex index)
 {
     return mCombatEntityLists[index.mValue];
+}
+
+std::optional<CombatRelInfo> GameState::GetCombatRelInfo(CombatantIndex combatant) const
+{
+    for (unsigned combatIx = 0; combatIx < mCombatEntityLists.size(); combatIx++)
+    {
+        const auto& entityList = mCombatEntityLists[combatIx].mCombatants;
+        for (unsigned combatantIx = 0; combatantIx < entityList.size(); combatantIx++)
+        {
+            if (entityList[combatantIx] == combatant)
+            {
+                return CombatRelInfo{CombatIndex{combatIx}, combatantIx};
+            }
+        }
+    }
+
+    return std::nullopt;
+}
+
+GenericContainer* GameState::GetCombatContainer(CombatRelInfo info)
+{
+    auto& containers = GetCombatContainers();
+    auto container = std::find_if(containers.begin(), containers.end(),
+        [&](auto& lhs){
+            return lhs.GetHeader().GetCombatNumber() == info.mCombatIndex
+                && lhs.GetHeader().GetCombatantNumber() == info.mCombatantRelativeIndex;
+        });
+    if (container != containers.end())
+    {
+        return &(*container);
+    }
+
+    return nullptr;
 }
 
 void GameState::ReactivateCombat(const Encounter::Encounter& encounter, CombatIndex combatIndex)

--- a/bak/gameState.hpp
+++ b/bak/gameState.hpp
@@ -192,13 +192,13 @@ public:
     CombatantGridLocation& GetCombatantGridLocation(CombatantIndex);
     Character* GetCombatantCharacter(CombatantIndex);
     CombatEntityList& GetCombatEntityList(CombatIndex);
+    std::optional<CombatRelInfo> GetCombatRelInfo(CombatantIndex combatant) const;
+    GenericContainer* GetCombatContainer(CombatRelInfo);
     void ReactivateCombat(const Encounter::Encounter&, CombatIndex);
 
     // Super lame, but BaK uses a global so I will too
     void SetCombatTriggeredFromInteractable(bool value) { mCombatTriggeredFromInteractable = value; }
     bool GetCombatTriggeredFromInteractable() const { return mCombatTriggeredFromInteractable; }
-
-    void SetFixCombatEntityLists(bool value) { mFixCombatEntityLists = value; }
 
     PartyChangeCache& GetPartyChangeCache() { return mPartyChangeCache; }
 
@@ -229,7 +229,6 @@ private:
     unsigned mContextVar_753f{};
     PartyChangeCache mPartyChangeCache{};
     bool mCombatTriggeredFromInteractable{};
-    bool mFixCombatEntityLists{false};
 
     std::optional<InventoryItem> mSelectedItem{};
     std::optional<MonsterIndex> mCurrentMonster{};

--- a/bak/save/combat.cpp
+++ b/bak/save/combat.cpp
@@ -75,7 +75,7 @@ std::vector<Skills> LoadCombatStats(FileBuffer& fb)
 Character LoadCombatant(
     CombatantIndex combatant,
     FileBuffer& fb,
-    GenericContainer& container)
+    Inventory* inventory)
 {
     const auto& logger = Logging::LogState::GetLogger("LoadCombatant");
     const auto offset = SaveOffsets::sCombatStatsOffset
@@ -107,7 +107,7 @@ Character LoadCombatant(
         combatCharIndex,
         unknown2,
         Conditions{},
-        &container.GetInventory()};
+        inventory};
 }
 
 std::vector<CombatantGridLocation> LoadCombatantGridLocations(FileBuffer& fb)

--- a/bak/save/combat.hpp
+++ b/bak/save/combat.hpp
@@ -11,7 +11,7 @@ namespace BAK {
 
 class Character;
 class FileBuffer;
-class GenericContainer;
+class Inventory;
 
 std::vector<CombatEntityList> LoadCombatEntityLists(FileBuffer&);
 std::vector<CombatantGridLocation> LoadCombatantGridLocations(FileBuffer&);
@@ -19,7 +19,7 @@ std::vector<CombatWorldLocation> LoadCombatWorldLocations(FileBuffer&);
 std::vector<Skills> LoadCombatStats(FileBuffer&);
 std::vector<Time> LoadCombatClickedTimes(FileBuffer&);
 
-Character LoadCombatant(CombatantIndex, FileBuffer&, GenericContainer&);
+Character LoadCombatant(CombatantIndex, FileBuffer&, Inventory* inventory);
 
 void Save(const std::vector<CombatantGridLocation>&, FileBuffer& fb);
 void Save(const std::vector<CombatWorldLocation>&, FileBuffer&);

--- a/config.json
+++ b/config.json
@@ -21,10 +21,6 @@
     },
     "Game": {
         "AdvanceTime": true,
-        // Set this to true to fix the combat entity lists in the game
-        // Note: the lists in the original are bugged, so this fixes it
-        // but if you care about fidelity to the original leave this off
-        "FixCombatEntityLists": false,
         "CombatSpeed": 1.0
     },
     "Logging": {

--- a/game/gameRunner.cpp
+++ b/game/gameRunner.cpp
@@ -375,18 +375,14 @@ void GameRunner::LoadTileActors(std::uint8_t tileIndex)
                     &actor.mLocation,
                     &actor.mModelMatrix});
 
-            auto& containers = mGameState.GetCombatContainers();
-            auto container = std::find_if(containers.begin(), containers.end(),
-                [&](auto& lhs){
-                    return lhs.GetHeader().GetCombatNumber() == combat.mCombatIndex
-                        && lhs.GetHeader().GetCombatantNumber() == i;
-                });
-
-            if (container != containers.end())
+            auto* container = mGameState.GetCombatContainer(BAK::CombatRelInfo{combat.mCombatIndex, i});
+            if (container)
             {
-                const auto entityType = combatComplete ? BAK::EntityType::DEAD_COMBATANT : BAK::EntityType::LIVING_COMBATANT;
+                const auto entityType = combatComplete
+                    ? BAK::EntityType::DEAD_COMBATANT
+                    : BAK::EntityType::LIVING_COMBATANT;
                 mSystems->AddClickable(Clickable{entityId});
-                mClickables.emplace(entityId, ClickableEntity(entityType, &(*container)));
+                mClickables.emplace(entityId, ClickableEntity(entityType, container));
             }
         }
 
@@ -910,7 +906,7 @@ void GameRunner::SetCombatantDirection(
 {
     auto* actor = mCombatActorStore.GetActor(entityId);
     assert(actor);
-    mLogger.Debug() << "Setting combatant direction: " << entityId 
+    mLogger.Spam() << "Setting combatant direction: " << entityId
         << " dir: " << static_cast<unsigned>(direction) << "\n";
     actor->mDirection = direction;
     actor->Update();

--- a/gui/combat/combatScreen.cpp
+++ b/gui/combat/combatScreen.cpp
@@ -214,7 +214,6 @@ void CombatScreen::PrintMeleeInformation(BAK::MeleeInfo info)
         ss << "Left\n";
     }
     mTextArea.SetText(mFont, ss.str(), true);
-    mLogger.Debug() << "Print melee info: " << ss.str();
 }
 
 void CombatScreen::HandleButton(unsigned buttonIndex)


### PR DESCRIPTION
Reading the game code more closely, there is no guarantee that combat entity list entity ids map directly to combat inventory indices.

The game only loads combat inventories based on the combat id and relative combatant number.

When I load combatants, change the logic to back out the combat id and rel combatant number from the combatant entity id.