### PR TITLE
Issue #287 - apply damage in combat

### DIFF
--- a/bak/CMakeLists.txt
+++ b/bak/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(bak
     chapterTransitions.hpp chapterTransitions.cpp
     combat/combat.hpp combat/combat.cpp
     combat/calculations.hpp combat/calculations.cpp
+    combat/spellEffects.hpp combat/spellEffects.cpp
     combat/combatModel.hpp combat/combatModel.cpp
     combat/retreat.hpp combat/retreat.cpp
     combat/types.hpp combat/types.cpp

--- a/bak/combat/calculations.cpp
+++ b/bak/combat/calculations.cpp
@@ -1,4 +1,5 @@
 #include "bak/combat/calculations.hpp"
+#include "bak/combat/spellEffects.hpp"
 
 #include "bak/character.hpp"
 #include "bak/combat/types.hpp"
@@ -6,6 +7,7 @@
 #include "bak/inventoryItem.hpp"
 #include "bak/monster.hpp"
 #include "bak/sounds.hpp"
+#include "bak/spells.hpp"
 
 #include "com/random.hpp"
 
@@ -29,6 +31,29 @@ static const std::array<std::uint16_t, 64> sMonsterResistanceArr = {
     0x200, 0x100, 0x300, 1, 1, 0,    0, 0, 0,    0xC0, 0xC0,  0,    0,     0, 0x300, 0
  };
 
+bool IsCombatantActive(CombatState& combatState, bool checkPending)
+{
+    if (checkPending)
+    {
+        if (!combatState.mTurnPending || combatState.mIsDead)
+        {
+            return false;
+        }
+    }
+
+    for (const auto& effect : combatState.mSpellEffects)
+    {
+        switch (effect.mEffectId)
+        {
+        case sDannonsDelusions: [[fallthrough]];
+        case sDespairThyEyes: [[fallthrough]];
+        case sGriefOf1000Nights: return false;
+        default: break;
+        }
+    }
+
+    return true;
+}
 
 MeleeInfo CalculateMeleeInfo(Character& character)
 {
@@ -577,85 +602,182 @@ void PoisonCombatant(Character& combatant, CombatState& state)
     combatant.AdjustCondition(BAK::Condition::Poisoned, poisonAmount);
 }
 
-bool IsCombatantActive(CombatState& combatState, bool checkPending)
+[[nodiscard]] bool ApplyPoisonAtEndOfTurn(Character& character, CombatState& combatState)
 {
-    if (checkPending)
+    int damageAmount = GetRandomNumber(1, 2);
+    bool useArmor = false;
+    int damageType = 2;
+    std::uint16_t modifierFlags = std::to_underlying(ModifierFlags::Poison);
+    // this is kinda surprising, test this...
+    bool ignoreShields = false;
+
+    return DamageCombatant(
+        character,
+        character.GetMonsterIndex(),
+        combatState,
+        damageAmount,
+        useArmor,
+        damageType,
+        modifierFlags,
+        ignoreShields);
+}
+
+[[nodiscard]] bool DamageCombatant(
+    Character& character,
+    MonsterIndex monster,
+    CombatState& combatState,
+    int originalDamage,
+    bool useArmor,
+    unsigned damageType,
+    std::uint16_t modifierFlags,
+    bool ignoreShields)
+{
+    auto& skills = character.GetSkills();
     {
-        if (!combatState.mTurnPending || combatState.mIsDead)
+        auto health = skills.GetSkill(SkillType::Health);
+        auto stamina = skills.GetSkill(SkillType::Stamina);
+
+        Logging::LogDebug(__FUNCTION__) << " Dead: " << combatState.mIsDead << " Before: \nHealth "
+            << health << "\nStamina " << stamina << "\n";
+    }
+
+    if (monster == sWindElemental)
+    {
+        return false;
+    }
+
+    if (GetSpellEffect(combatState, sDannonsDelusions))
+    {
+        return false;
+    }
+
+    if (combatState.mIsDead)
+    {
+        return false;
+    }
+
+    if (originalDamage < 1)
+    {
+        return false;
+    }
+
+    auto damage = originalDamage;
+
+    if (useArmor)
+    {
+        auto reduction = CalculateArmorReduction(character);
+        damage = damage * (100 - reduction) / 100;
+        if (damage <= 0)
+        {
+            damage = GetRandomNumber(1, 2);
+        }
+        Logging::LogDebug(__FUNCTION__) << " After armor ("
+            << reduction << "% reduction): " << damage << "\n";
+    }
+
+    auto* shieldEffect = GetSpellEffect(combatState, sHochosHaven);
+    if (!ignoreShields && shieldEffect)
+    {
+        shieldEffect->mAmount -= damage;
+        damage = 0;
+
+        int shieldLeft = shieldEffect->mAmount;
+        if (shieldLeft < 0)
+        {
+            damage = -shieldLeft;
+        }
+
+        if (damage == 0)
         {
             return false;
         }
     }
 
-    for (const auto& effect : combatState.mSpellEffects)
+    if (!ignoreShields)
     {
-        switch (effect.mEffectId)
+        auto* skinEffect = GetSpellEffect(combatState, sSkinOfTheDragon);
+        if (skinEffect)
         {
-        case sDannonsDelusions: [[fallthrough]];
-        case sDespairThyEyes: [[fallthrough]];
-        case sGriefOf1000Nights: return false;
-        default: break;
+            damage = 0;
         }
     }
 
-    return true;
-}
+    Logging::LogDebug(__FUNCTION__) << " After shield/skin: " << damage << "\n";
 
-bool TickCombatEffects(CombatState& combatState)
-{
-    auto& effects = combatState.mSpellEffects;
-    bool expiredCharacter = false;
+    damage = CalculateMonsterWeakness(character.GetMonsterIndex(), modifierFlags, damage);
+    damage = CalculateMonsterResistance(character.GetMonsterIndex(), modifierFlags, damage);
 
-    for (auto& effect : effects)
+    Logging::LogDebug(__FUNCTION__) << " After weakness/resistance: " << damage << "\n";
+
+    if (damage > 0 && (modifierFlags & std::to_underlying(ModifierFlags::Poison)))
     {
-        effect.mAmount--;
+        PoisonCombatant(character, combatState);
+    }
 
-        if (effect.mAmount == 0 && effect.mEffectId == sDannonsDelusions)
+    auto& stamina = character.GetSkills().GetSkill(SkillType::Stamina);
+    if (stamina.mTrueSkill < damage)
+    {
+        auto excessDamage = damage - stamina.mTrueSkill;
+        stamina.mTrueSkill = 0;
+        auto& health = character.GetSkills().GetSkill(SkillType::Health);
+
+        if (health.mTrueSkill < excessDamage)
         {
-            expiredCharacter = true;
+            health.mTrueSkill = 0;
+        }
+        else
+        {
+            health.mTrueSkill -= excessDamage;
         }
     }
+    else
+    {
+        stamina.mTrueSkill -= damage;
+    }
 
-    effects.erase(
-        std::remove_if(effects.begin(), effects.end(), [](auto& effect)
+    if (originalDamage > 0 && damageType != 0)
+    {
+        unsigned displayDamage = 1;
+        if (originalDamage < 1000)
         {
-            return effect.mAmount == 0;
-        }),
-        effects.end());
-
-    return expiredCharacter;
-}
-
-SpellEffect* GetSpellEffect(CombatState& combatState, unsigned effectId)
-{
-    auto& effects = combatState.mSpellEffects;
-    auto it = std::find_if(effects.begin(), effects.end(), [effectId](const auto& effect)
+            displayDamage = originalDamage;
+        }
+    }
+    else if (damageType != 0)
     {
-        return effect.mEffectId == effectId;
-    });
-
-    if (it != effects.end())
-    {
-        return &(*it);
+        unsigned displayDamage = 1;
     }
 
-    return nullptr;
-}
-
-void RemoveSpellEffect(CombatState& combatState, unsigned effectId)
-{
-    auto& effects = combatState.mSpellEffects;
-    auto it = std::find_if(effects.begin(), effects.end(), [effectId](const auto& effect)
+    if ((modifierFlags & std::to_underlying(ModifierFlags::Fire)) != 0)
     {
-        return effect.mEffectId == effectId;
-    });
-
-    if (it == effects.end())
-    {
-        return;
     }
 
-    effects.erase(it);
+    if (modifierFlags & std::to_underlying(ModifierFlags::Frost))
+    {
+    }
+
+    if (modifierFlags & std::to_underlying(ModifierFlags::Poison))
+    {
+    }
+
+    auto& health = character.GetSkills().GetSkill(SkillType::Health);
+    if (health.mTrueSkill == 0)
+    {
+        CleanCharacterStateOnDeath(character, combatState);
+        combatState.mIsExorcised = false;
+    }
+
+    character.GetSkill(SkillType::TotalHealth);
+
+    {
+        auto health = skills.GetSkill(SkillType::Health);
+        auto stamina = skills.GetSkill(SkillType::Stamina);
+
+        Logging::LogDebug(__FUNCTION__) << " Dead: " << combatState.mIsDead << " Before: \nHealth "
+            << health << "\nStamina " << stamina << "\n";
+    }
+
+    return combatState.mIsDead;
 }
 
 }

--- a/bak/combat/calculations.cpp
+++ b/bak/combat/calculations.cpp
@@ -83,8 +83,12 @@ int CalculateParry(
     Character& defender,
     CombatState& defenderState)
 {
-    // TODO: there are some attributes that cause the defender skill to be ignored
     auto parry = defender.GetSkill(SkillType::Defense) / 4;
+
+    if (!IsCombatantActive(defenderState, false))
+    {
+        parry = 0;
+    }
 
     auto* armor = defender.GetArmor();
     if (armor)
@@ -571,6 +575,87 @@ void PoisonCombatant(Character& combatant, CombatState& state)
     auto poisonAmount = (GetRandomNumber(0, 0xfff) % 50) + 10;
 
     combatant.AdjustCondition(BAK::Condition::Poisoned, poisonAmount);
+}
+
+bool IsCombatantActive(CombatState& combatState, bool checkPending)
+{
+    if (checkPending)
+    {
+        if (!combatState.mTurnPending || combatState.mIsDead)
+        {
+            return false;
+        }
+    }
+
+    for (const auto& effect : combatState.mSpellEffects)
+    {
+        switch (effect.mEffectId)
+        {
+        case sDannonsDelusions: [[fallthrough]];
+        case sDespairThyEyes: [[fallthrough]];
+        case sGriefOf1000Nights: return false;
+        default: break;
+        }
+    }
+
+    return true;
+}
+
+bool TickCombatEffects(CombatState& combatState)
+{
+    auto& effects = combatState.mSpellEffects;
+    bool expiredCharacter = false;
+
+    for (auto& effect : effects)
+    {
+        effect.mAmount--;
+
+        if (effect.mAmount == 0 && effect.mEffectId == sDannonsDelusions)
+        {
+            expiredCharacter = true;
+        }
+    }
+
+    effects.erase(
+        std::remove_if(effects.begin(), effects.end(), [](auto& effect)
+        {
+            return effect.mAmount == 0;
+        }),
+        effects.end());
+
+    return expiredCharacter;
+}
+
+SpellEffect* GetSpellEffect(CombatState& combatState, unsigned effectId)
+{
+    auto& effects = combatState.mSpellEffects;
+    auto it = std::find_if(effects.begin(), effects.end(), [effectId](const auto& effect)
+    {
+        return effect.mEffectId == effectId;
+    });
+
+    if (it != effects.end())
+    {
+        return &(*it);
+    }
+
+    return nullptr;
+}
+
+void RemoveSpellEffect(CombatState& combatState, unsigned effectId)
+{
+    auto& effects = combatState.mSpellEffects;
+    auto it = std::find_if(effects.begin(), effects.end(), [effectId](const auto& effect)
+    {
+        return effect.mEffectId == effectId;
+    });
+
+    if (it == effects.end())
+    {
+        return;
+    }
+
+    effects.erase(it);
 }
 
 }

--- a/bak/combat/calculations.hpp
+++ b/bak/combat/calculations.hpp
@@ -11,6 +11,7 @@ namespace BAK {
 
 class Character;
 struct CombatState;
+struct SpellEffect;
 struct MeleeInfo;
 enum class MeleeResult;
 enum class ItemType;
@@ -55,6 +56,11 @@ int CalculateParry(Character& defender, CombatState& state);
 int CalculateAccuracyBonus(int raceEffect, int condition, int accuracy);
 int CalculateBlessingEffect(int value, std::vector<Modifier> modifiers);
 int CalculateArmorModReduction(Modifier modifier, const std::vector<Modifier>& modifiers, int armor);
-void PoisonCombatant(Character& combatant);
+void PoisonCombatant(Character&, CombatState&);
+
+bool IsCombatantActive(CombatState& combatState, bool checkPending);
+bool TickCombatEffects(CombatState& combatState);
+SpellEffect* GetSpellEffect(CombatState& combatState, unsigned effectId);
+void RemoveSpellEffect(CombatState& combatState, unsigned effectId);
 
 }

--- a/bak/combat/calculations.hpp
+++ b/bak/combat/calculations.hpp
@@ -11,7 +11,6 @@ namespace BAK {
 
 class Character;
 struct CombatState;
-struct SpellEffect;
 struct MeleeInfo;
 enum class MeleeResult;
 enum class ItemType;
@@ -19,7 +18,7 @@ enum class ItemType;
 static constexpr auto sDullFull = 0x100;
 static constexpr auto sDullHalf = 0x80;
 
-enum class ModifierFlags
+enum class ModifierFlags : std::uint16_t
 {
     Poison   = 0x1,
     Frost    = 0x2,
@@ -28,6 +27,8 @@ enum class ModifierFlags
     Enhance2 = 0x20,
     Bless    = 0x800,
 };
+
+bool IsCombatantActive(CombatState& combatState, bool checkPending);
 
 MeleeInfo CalculateMeleeInfo(Character&);
 MeleeResult CalculateMeleeResult(
@@ -57,10 +58,15 @@ int CalculateAccuracyBonus(int raceEffect, int condition, int accuracy);
 int CalculateBlessingEffect(int value, std::vector<Modifier> modifiers);
 int CalculateArmorModReduction(Modifier modifier, const std::vector<Modifier>& modifiers, int armor);
 void PoisonCombatant(Character&, CombatState&);
-
-bool IsCombatantActive(CombatState& combatState, bool checkPending);
-bool TickCombatEffects(CombatState& combatState);
-SpellEffect* GetSpellEffect(CombatState& combatState, unsigned effectId);
-void RemoveSpellEffect(CombatState& combatState, unsigned effectId);
+[[nodiscard]] bool ApplyPoisonAtEndOfTurn(Character& , CombatState&);
+[[nodiscard]] bool DamageCombatant(
+    Character& character,
+    MonsterIndex monster,
+    CombatState& combatState,
+    int originalDamage,
+    bool useArmor,
+    unsigned damageType,
+    std::uint16_t modifierFlags,
+    bool avoidsShields);
 
 }

--- a/bak/combat/combat.cpp
+++ b/bak/combat/combat.cpp
@@ -11,14 +11,14 @@
 
 namespace BAK {
 
-std::string_view ToString(CombatResult r)
+std::string_view ToString(CombatOutcome r)
 {
     switch (r)
     {
-        case CombatResult::None: return "None";
-        case CombatResult::Won: return "Won";
-        case CombatResult::Fled: return "Fled";
-        case CombatResult::Dead: return "Dead";
+        case CombatOutcome::None: return "None";
+        case CombatOutcome::Won: return "Won";
+        case CombatOutcome::Fled: return "Fled";
+        case CombatOutcome::Dead: return "Dead";
     }
     return "Unknown";
 }

--- a/bak/combat/combat.hpp
+++ b/bak/combat/combat.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "bak/coordinates.hpp"
+#include "bak/dialogTarget.hpp"
 
 #include <cstdint>
 #include <iosfwd>
@@ -10,7 +11,7 @@
 
 namespace BAK {
 
-enum class CombatResult : std::uint8_t
+enum class CombatOutcome : std::uint8_t
 {
     None = 0,
     Won = 1,
@@ -18,7 +19,14 @@ enum class CombatResult : std::uint8_t
     Dead = 3
 };
 
-std::string_view ToString(CombatResult);
+std::string_view ToString(CombatOutcome);
+
+struct CombatResult
+{
+    CombatOutcome mOutcome{};
+    BAK::Target mDialog{};
+    unsigned mContextVar{};
+};
 
 enum class CombatantWorldState : std::uint8_t
 {

--- a/bak/combat/spellEffects.cpp
+++ b/bak/combat/spellEffects.cpp
@@ -1,0 +1,85 @@
+#include "bak/combat/spellEffects.hpp"
+
+#include "bak/character.hpp"
+#include "bak/combat/types.hpp"
+#include "bak/condition.hpp"
+#include "bak/skills.hpp"
+#include "bak/spells.hpp"
+
+#include <algorithm>
+
+namespace BAK {
+
+[[nodiscard]] bool TickCombatEffects(CombatState& combatState)
+{
+    auto& effects = combatState.mSpellEffects;
+    bool expiredCharacter = false;
+
+    for (auto& effect : effects)
+    {
+        effect.mAmount--;
+
+        if (effect.mAmount == 0 && effect.mEffectId == sDannonsDelusions)
+        {
+            expiredCharacter = true;
+        }
+    }
+
+    effects.erase(
+        std::remove_if(effects.begin(), effects.end(), [](auto& effect)
+        {
+            return effect.mAmount == 0;
+        }),
+        effects.end());
+
+    return expiredCharacter;
+}
+
+SpellEffect* GetSpellEffect(CombatState& combatState, unsigned effectId)
+{
+    auto& effects = combatState.mSpellEffects;
+    auto it = std::find_if(effects.begin(), effects.end(), [effectId](const auto& effect)
+    {
+        return effect.mEffectId == effectId;
+    });
+
+    if (it != effects.end())
+    {
+        return &(*it);
+    }
+
+    return nullptr;
+}
+
+void RemoveSpellEffect(CombatState& combatState, unsigned effectId)
+{
+    auto& effects = combatState.mSpellEffects;
+    auto it = std::find_if(effects.begin(), effects.end(), [effectId](const auto& effect)
+    {
+        return effect.mEffectId == effectId;
+    });
+
+    if (it == effects.end())
+    {
+        return;
+    }
+
+    effects.erase(it);
+}
+
+void CleanCharacterStateOnDeath(Character& character, CombatState& combatState)
+{
+    combatState.mSpellEffects.clear();
+
+    auto& skills = character.GetSkills();
+    skills.GetSkill(SkillType::Health).mTrueSkill = 0;
+    character.GetSkill(SkillType::Health);
+    skills.GetSkill(SkillType::Stamina).mTrueSkill = 0;
+    character.GetSkill(SkillType::Stamina);
+
+    combatState.mIsDead = true;
+
+    character.AdjustCondition(BAK::Condition::NearDeath, 100);
+}
+
+}

--- a/bak/combat/spellEffects.hpp
+++ b/bak/combat/spellEffects.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace BAK {
+
+class Character;
+struct CombatState;
+struct SpellEffect;
+
+[[nodiscard]] bool TickCombatEffects(CombatState& combatState);
+SpellEffect* GetSpellEffect(CombatState& combatState, unsigned effectId);
+void RemoveSpellEffect(CombatState& combatState, unsigned effectId);
+void CleanCharacterStateOnDeath(Character& character, CombatState& combatState);
+
+}

--- a/bak/combat/types.cpp
+++ b/bak/combat/types.cpp
@@ -1,4 +1,5 @@
 #include "bak/combat/types.hpp"
+#include "com/ostream.hpp"
 
 namespace BAK {
 
@@ -9,6 +10,34 @@ std::ostream& operator<<(std::ostream& os, AttackType type)
     case AttackType::Slash: return os << "Slash";
     case AttackType::Thrust: return os << "Thrust";
     }
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const SpellEffect& se)
+{
+    os << "SpellEffect{"
+        << "id: " << se.mEffectId
+        << ", paramA: " << se.mParamA
+        << ", amount: " << se.mAmount
+        << ", counter: " << se.mCounter
+        << ", flags: " << +se.mFlags
+        << "}";
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const CombatState& state)
+{
+    os << "CombatState{"
+        << std::boolalpha
+        << "turnPending: " << state.mTurnPending
+        << ", isDead: " << state.mIsDead
+        << ", isPoisoned: " << state.mIsPoisoned
+        << ", isDefending: " << state.mIsDefending
+        << ", isFrozen: " << state.mIsFrozen
+        << ", isExorcised: " << state.mIsExorcised
+        << ", isFleeing: " << state.mIsFleeing
+        << ", spellEffects: [" << state.mSpellEffects << "]"
+        << "}";
     return os;
 }
 

--- a/bak/combat/types.hpp
+++ b/bak/combat/types.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ostream>
+#include <vector>
 
 namespace BAK {
 
@@ -18,6 +19,15 @@ enum class MeleeResult
     Hit
 };
 
+struct SpellEffect
+{
+    std::uint16_t mEffectId;
+    std::uint16_t mParamA;
+    int mAmount;
+    std::uint16_t mCounter;
+    std::uint8_t mFlags;
+};
+
 struct CombatState
 {
     bool mTurnPending{true};
@@ -25,7 +35,11 @@ struct CombatState
     bool mIsPoisoned{false};
     bool mIsDefending{false};
     bool mIsFrozen{false};
+    bool mIsExorcsed{false};
     bool mIsFleeing{false};
+
+    //std::optional<GridPos> mCurrentTarget;
+    std::vector<SpellEffect> mSpellEffects{};
 };
 
 enum class AttackType

--- a/bak/combat/types.hpp
+++ b/bak/combat/types.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <ostream>
 #include <vector>
 
@@ -28,6 +29,8 @@ struct SpellEffect
     std::uint8_t mFlags;
 };
 
+std::ostream& operator<<(std::ostream& os, const SpellEffect& se);
+
 struct CombatState
 {
     bool mTurnPending{true};
@@ -35,12 +38,14 @@ struct CombatState
     bool mIsPoisoned{false};
     bool mIsDefending{false};
     bool mIsFrozen{false};
-    bool mIsExorcsed{false};
+    bool mIsExorcised{false};
     bool mIsFleeing{false};
 
     //std::optional<GridPos> mCurrentTarget;
     std::vector<SpellEffect> mSpellEffects{};
 };
+
+std::ostream& operator<<(std::ostream& os, const CombatState& state);
 
 enum class AttackType
 {

--- a/bak/monster.hpp
+++ b/bak/monster.hpp
@@ -20,6 +20,7 @@ static constexpr auto sBulldrakeWyvern      = MonsterIndex{41};
 static constexpr auto sGrandsireWyvern      = MonsterIndex{42};
 static constexpr auto sHatchlingWyvern      = MonsterIndex{43};
 static constexpr auto sTroll                = MonsterIndex{48};
+static constexpr auto sWindElemental        = MonsterIndex{54};
 static constexpr auto sNethermander         = MonsterIndex{58};
 
 class MonsterNames

--- a/bak/monster.hpp
+++ b/bak/monster.hpp
@@ -22,6 +22,8 @@ static constexpr auto sHatchlingWyvern      = MonsterIndex{43};
 static constexpr auto sTroll                = MonsterIndex{48};
 static constexpr auto sWindElemental        = MonsterIndex{54};
 static constexpr auto sNethermander         = MonsterIndex{58};
+static constexpr auto sBlackslayer          = MonsterIndex{22};
+static constexpr auto sNighthawk            = MonsterIndex{23};
 
 class MonsterNames
 {

--- a/bak/spells.hpp
+++ b/bak/spells.hpp
@@ -11,6 +11,12 @@
 
 namespace BAK {
 
+static constexpr auto sDannonsDelusions = 1;
+static constexpr auto sDespairThyEyes = 3;
+static constexpr auto sHochosHaven    = 6;
+static constexpr auto sGriefOf1000Nights = 13;
+static constexpr auto sSkinOfTheDragon = 23;
+
 enum class StaticSpells : std::uint16_t
 {
     DragonsBreath = 0,

--- a/game/combat/ICombatStage.hpp
+++ b/game/combat/ICombatStage.hpp
@@ -2,8 +2,10 @@
 
 #include "bak/coordinates.hpp"
 #include "bak/types.hpp"
+#include "bak/combat/combat.hpp"
 #include "bak/combat/combatModel.hpp"
 
+#include <functional>
 #include <glm/glm.hpp>
 
 namespace Game::Combat {
@@ -12,24 +14,35 @@ class ICombatStage
 {
 public:
     virtual void MoveCombatant(
-        BAK::EntityIndex entityId,
+        BAK::EntityIndex,
         glm::uvec2 sourceGrid,
         glm::uvec2 targetGrid) = 0;
 
     virtual void SetCombatantAction(
-        BAK::EntityIndex entityId,
+        BAK::EntityIndex,
         BAK::AnimationType animType) = 0;
 
     virtual void SetCombatantDirection(
-        BAK::EntityIndex entityId,
-        BAK::Direction direction) = 0;
+        BAK::EntityIndex,
+        BAK::Direction) = 0;
+
+    virtual void SetCombatantUpdateIdle(
+        BAK::EntityIndex,
+        bool) = 0;
 
     virtual void AnimateCombatant(
-        BAK::EntityIndex entityId) = 0;
+        BAK::EntityIndex) = 0;
+
+    virtual void AnimateCombatant(
+        BAK::EntityIndex,
+        std::function<void()>) = 0;
 
     virtual void AnimateAttack(
-        BAK::EntityIndex entityId,
+        BAK::EntityIndex,
         glm::uvec2 targetGrid) = 0;
+
+    virtual void CombatFinished(
+        BAK::CombatResult) = 0;
 
     virtual ~ICombatStage() = default;
 };

--- a/game/combat/actorStore.hpp
+++ b/game/combat/actorStore.hpp
@@ -30,6 +30,7 @@ public:
 
     const CombatModelLoader& mCombatModelLoader;
     glm::mat4 mModelMatrix{1.0f};
+    bool mUpdateIdle{true};
     bool mAnimating{false};
 
     Actor(
@@ -78,6 +79,11 @@ public:
         Update();
     }
 
+    void SetUpdateIdle(bool update)
+    {
+        mUpdateIdle = update;
+    }
+
     void SetState(BAK::AnimationType type, BAK::Direction direction)
     {
         mAnimationType = type;
@@ -97,11 +103,16 @@ public:
         if (auto anim = GetAnimData())
         {
             auto frameCount = anim->mMeta.mFrames;
-            if (frameCount > 0)
-                mFrame %= frameCount;
+            if (frameCount > 0
+                && mFrame >= static_cast<int>(frameCount))
+            {
+                mFrame = frameCount - 1;
+                ApplyFrame(*anim);
+                return true;
+            }
             ApplyFrame(*anim);
         }
-        return mFrame == 0;
+        return false;
     }
 
     void AdvanceIdleFrame()
@@ -139,7 +150,7 @@ public:
 
     bool AdvanceIdle(double timeDelta)
     {
-        if (mAnimating) return false;
+        if (mAnimating || !mUpdateIdle) return false;
         mIdleAccumulator += timeDelta;
         if (mIdleAccumulator < mIdleInterval) return false;
         mIdleAccumulator -= mIdleInterval;
@@ -159,12 +170,8 @@ public:
     }
 
 private:
-    int mFrame{0};
-    int mIdleDelta{1};
-    double mIdleAccumulator{0};
-    double mIdleInterval{0.5};
-
-    struct AnimData {
+    struct AnimData
+    {
         const CombatModelData* mDatas;
         AnimationMeta mMeta;
     };
@@ -194,6 +201,11 @@ private:
         mModelMatrix = Graphics::CalculateModelMatrix(
             mLocation, mScale, adjustedRotation, BAK::gWorldScale);
     }
+
+    int mFrame{0};
+    int mIdleDelta{1};
+    double mIdleAccumulator{0};
+    double mIdleInterval{0.5};
 };
 
 

--- a/game/combat/combatManager.cpp
+++ b/game/combat/combatManager.cpp
@@ -1,12 +1,15 @@
 #include "game/combat/combatManager.hpp"
 
+#include "game/combat/gridAlgorithms.hpp"
+
 #include "audio/audio.hpp"
 
 #include "bak/combat/types.hpp"
+#include "bak/dialogSources.hpp"
 #include "bak/monster.hpp"
-#include "game/combat/gridAlgorithms.hpp"
 
 #include "bak/combat/calculations.hpp"
+#include "bak/combat/spellEffects.hpp"
 #include "bak/sounds.hpp"
 
 #include "com/bits.hpp"
@@ -101,7 +104,13 @@ std::vector<Combatant> CombatManager::GetCombatants()
 void CombatManager::BeginCombat()
 {
     mCombatActive = true;
-    SetCurrentCombatant(true);
+
+    auto it = SelectNextCombatantForTurn(true);
+    assert(it != mCombatants.end());
+
+    auto index = std::distance(mCombatants.begin(), it);
+    SetCurrentCombatant(index);
+
 }
 
 Combatant& CombatManager::GetCurrentCombatant()
@@ -233,57 +242,6 @@ bool CombatManager::IsCombatActive() const
     return mCombatActive;
 }
 
-void CombatManager::SetCurrentCombatant(bool onlyParty)
-{
-    std::optional<unsigned> bestSpeed{};
-    auto combatantIndex = 0;
-    for (unsigned i = 0; i < mCombatants.size(); i++)
-    {
-        auto& combatant = mCombatants[i];
-        auto* character = combatant.mCharacter;
-        if (!character)
-        {
-            continue;
-        }
-
-        if (onlyParty && character->IsEnemy())
-        {
-            continue;
-        }
-
-        if (!combatant.GetTurnPending())
-        {
-            continue;
-        }
-
-        // Find best PC then find best AI
-        // then select between them to store some state for AI specifically..
-        auto speed = character->GetSkill(BAK::SkillType::Speed);
-        if (speed == 0 || combatant.IsDead())
-        {
-            speed = 1;
-        }
-
-        if (!bestSpeed || speed > *bestSpeed)
-        {
-            bestSpeed = speed;
-            combatantIndex = i;
-        }
-    }
-
-    mCurrentCombatant = combatantIndex;
-    auto& character = *GetCurrentCombatant().mCharacter;
-    if (!character.IsEnemy())
-    {
-        mCombatUI.SetSelectedCharacter(character.GetIndex());
-    }
-
-    ComputeGrid();
-
-    mLogger.Debug() << "Current combatant set to: " << combatantIndex << " " << GetCurrentCombatant().mCharacter->GetName()
-        << " charIndex: " << character.GetIndex().mValue << "\n";
-}
-
 void CombatManager::ComputeGrid()
 {
     ClearGrid();
@@ -364,13 +322,21 @@ void CombatManager::CompleteMove(GridPos target)
 void CombatManager::CompleteAttack(GridPos target)
 {
     auto& combatant = GetCurrentCombatant();
-
-    auto& enemy = mGrid.Get(target);
-
-    mStage.SetCombatantAction(enemy.mElement->mEntityIndex, BAK::AnimationType::Idle);
     mStage.SetCombatantAction(combatant.mEntityIndex, BAK::AnimationType::Idle);
 
-    FinishTurn();
+    auto& enemy = mGrid.Get(target);
+    assert(enemy.mElement);
+
+    if (enemy.mElement->IsDead())
+    {
+        mActions.Push(AnimateDeath{target});
+        ExecuteAction();
+    }
+    else
+    {
+        mStage.SetCombatantAction(enemy.mElement->mEntityIndex, BAK::AnimationType::Idle);
+        FinishTurn();
+    }
 }
 
 void CombatManager::ExecuteAction()
@@ -380,11 +346,8 @@ void CombatManager::ExecuteAction()
     auto action = mActions.Pop();
     std::visit(
         overloaded{
-            [&](const Move& move){
-                Execute(move);
-            },
-            [&](const Attack& attack){
-                Execute(attack);
+            [&](const auto& action){
+                Execute(action);
             }},
         action);
 }
@@ -406,8 +369,8 @@ void CombatManager::Execute(const Attack& attack)
     auto& target = *GetCombatant(attack.mTarget);
     assert(target.mCharacter);
 
-    mLogger.Debug() << "Execute: " << attack << " Me: " << *me.mCharacter
-        << "\nThem: " << *target.mCharacter << "\n";
+    //mLogger.Debug() << "Execute: " << attack << " Me: " << *me.mCharacter
+    //    << "\nThem: " << *target.mCharacter << "\n";
 
     me.mCharacter->ImproveSkill(BAK::SkillType::Melee, BAK::SkillChange::FractionOfSkill, 3);
     target.mCharacter->ImproveSkill(BAK::SkillType::Defense, BAK::SkillChange::FractionOfSkill, 3);
@@ -434,9 +397,25 @@ void CombatManager::Execute(const Attack& attack)
 
     if (!isThrust)
     {
-        DamageCombatant(target, 1, false, false, true, false);
+        int damage = 1;
+        bool useArmor = false;
+        int damageTypeMelee = 0;
+        std::uint16_t modifierFlags = 1;
+        bool ignoreShields = false;
+        bool died = BAK::DamageCombatant(
+            *target.mCharacter,
+            target.mMonster,
+            target.mCombatState,
+            damage,
+            useArmor,
+            damageTypeMelee,
+            modifierFlags,
+            ignoreShields);
+        assert(!died);
         // attacker.StateFlags &= (~0x40) // i.e. don't display the hit effect
     }
+
+    bool targetDied = false;
 
     if (attackResult == BAK::MeleeResult::Hit)
     {
@@ -454,16 +433,25 @@ void CombatManager::Execute(const Attack& attack)
         bool useArmor = true;
         bool damageTypeMelee = true;
         auto modifierFlags = BAK::GetMeleeModifierFlags(*me.mCharacter);
-        bool skipDirectDamage = false;
-        DamageCombatant(target, damage, useArmor, damageTypeMelee, modifierFlags, skipDirectDamage);
+        bool ignoreShields = false;
+        targetDied = BAK::DamageCombatant(
+            *target.mCharacter,
+            target.mMonster,
+            target.mCombatState,
+            damage,
+            useArmor,
+            damageTypeMelee,
+            modifierFlags,
+            ignoreShields);
     }
     else
     {
         target.mCharacter->ImproveSkill(BAK::SkillType::Defense, BAK::SkillChange::FractionOfSkill, 3);
 
-        if (targetIsDefending) // && isActive
+        if (targetIsDefending && BAK::IsCombatantActive(target.mCombatState, false))
         {
-            target.IsDefending() = false; // true??
+            // need to check if we reset this or not, I don't thikn we do
+            //target.IsDefending() = false; // true??
 
             auto* defenderWeapon = target.mCharacter->GetMeleeWeapon();
             auto defenderHasStaff = defenderWeapon && defenderWeapon->GetObject().mType == BAK::ItemType::Staff;
@@ -518,6 +506,18 @@ void CombatManager::Execute(const Attack& attack)
     mStage.AnimateAttack(entityIndex, attack.mTarget);
 }
 
+void CombatManager::Execute(const AnimateDeath& death)
+{
+    auto& cell = mGrid.Get(death.mTarget);
+    assert(cell.mElement);
+    auto& target = *cell.mElement;
+    mStage.SetCombatantUpdateIdle(target.mEntityIndex, false);
+    mStage.SetCombatantAction(target.mEntityIndex, BAK::AnimationType::Dead);
+    mStage.AnimateCombatant(
+        target.mEntityIndex,
+        [this]{ FinishTurn(); });
+}
+
 void CombatManager::FinishTurn()
 {
     auto& combatant = GetCurrentCombatant();
@@ -532,17 +532,253 @@ void CombatManager::FinishTurn()
     //    mStage.SetCombatantDirection(me.mEntityIndex, lookDirection);
     //}
 
-
-    auto it = std::find_if(mCombatants.begin(), mCombatants.end(), [](auto& c){ return c.GetTurnPending(); });
-    if (it == mCombatants.end())
+    if (!combatant.IsDead() && combatant.IsPoisoned())
     {
-        for (auto& combatant : mCombatants)
+        bool died = BAK::ApplyPoisonAtEndOfTurn(*combatant.mCharacter, combatant.mCombatState);
+        if (died)
         {
-            combatant.GetTurnPending() = true;
+            mActions.Push(AnimateDeath{combatant.mGridPos});
+            ExecuteAction();
         }
     }
 
-    SetCurrentCombatant(false);
+    if (auto result = CheckCombatFinished())
+    {
+        mLogger.Debug() << "Combat finished: " << ToString(result->mOutcome) << "\n";
+        //Cleanup();
+        mStage.CombatFinished(*result);
+        return;
+    }
+
+    auto it = SelectNextCombatantForTurn(false);
+
+    if (it == mCombatants.end())
+    {
+        mLogger.Debug() << "Turn completed\n";
+        StartNextTurn();
+    }
+
+    it = SelectNextCombatantForTurn(false);
+    auto index = std::distance(mCombatants.begin(), it);
+    SetCurrentCombatant(index);
+}
+
+void CombatManager::SetCurrentCombatant(unsigned index)
+{
+    mCurrentCombatant = index;
+    auto& character = *GetCurrentCombatant().mCharacter;
+    if (!character.IsEnemy())
+    {
+        mCombatUI.SetSelectedCharacter(character.GetIndex());
+    }
+
+    ComputeGrid();
+
+    mLogger.Debug() << "Current combatant set to: " << index << " " << GetCurrentCombatant().mCharacter->GetName()
+        << " charIndex: " << character.GetIndex().mValue << "\n";
+}
+
+std::optional<BAK::CombatResult> CombatManager::CheckCombatFinished()
+{
+    bool anyAIAlive = false;
+    bool anyPCAlive = false;
+    bool anyGhosts = false;
+    unsigned enemyCount = 0;
+    for (const auto& combatant : mCombatants)
+    {
+        if (!combatant.mCharacter)
+        {
+            continue;
+        }
+
+        if (!combatant.mCharacter->IsEnemy() && !anyPCAlive)
+        {
+            anyPCAlive = !combatant.IsDead();
+        }
+
+        if (combatant.mCharacter->IsEnemy() && !anyAIAlive)
+        {
+            anyAIAlive = !combatant.IsDead();
+            if (combatant.IsDead())
+            {
+                enemyCount++;
+            }
+        }
+    }
+
+    if (!anyPCAlive)
+    {
+        return BAK::CombatResult{BAK::CombatOutcome::Dead};
+    }
+
+    if (anyAIAlive)
+    {
+        return std::nullopt;
+    }
+
+    auto result = BAK::CombatResult{BAK::CombatOutcome::Won};
+    if (enemyCount > 1)
+    {
+        if (anyGhosts)
+        {
+            result.mDialog = BAK::DialogSources::mWonVersusGhosts;
+        }
+        else if (BAK::IsSpecialBattle(BAK::CombatIndex{0})) // mCombatIndex
+        {
+            result.mDialog = BAK::DialogSources::mWonSpecialBattle;
+        }
+        else
+        {
+            result.mDialog = BAK::DialogSources::mWonBattle;
+        }
+
+        return result;
+    }
+
+    if (anyGhosts)
+    {
+        result.mDialog = BAK::DialogSources::mWonVersusGhost;
+    }
+    else
+    {
+        result.mDialog = BAK::DialogSources::mDefeatedOneEnemy;
+    }
+
+    // FIXME THESE
+    // BAK::DialogSources::mSolvedTrap
+    // else if (NoCombatantsRemaining)
+    // BAK::DialogSources::mEnemyFled
+    return result;
+}
+
+void CombatManager::StartNextTurn()
+{
+    for (auto& combatant : mCombatants)
+    {
+        if (combatant.IsDead() || combatant.IsExorcised())
+        {
+            continue;
+        }
+
+        combatant.GetTurnPending() = true;
+        //combatant.Get(bit 4) = false
+        assert(combatant.mCharacter);
+        auto character = *combatant.mCharacter;
+        auto& speed = character.GetSkills().GetSkill(BAK::SkillType::Speed);
+        speed.mTrueSkill = speed.mMax;
+        character.GetSkill(BAK::SkillType::Health);
+        character.GetSkill(BAK::SkillType::Stamina);
+        character.GetSkill(BAK::SkillType::Speed);
+        character.GetSkill(BAK::SkillType::Strength);
+        character.GetSkill(BAK::SkillType::Crossbow);
+        character.GetSkill(BAK::SkillType::Melee);
+        character.GetSkill(BAK::SkillType::Casting);
+
+        if (speed.mCurrent == 0)
+        {
+            speed.mCurrent = 1;
+        }
+    }
+
+    TickCombatEffectsAtEndOfTurn();
+    //DamageAllCombatantsByWrathOfKillian();
+    ResurrectNighthawks();
+
+    // for each AI
+    //   mark as pending
+    //   clear bit 2 of state flags
+    //   if current target dead clear current target
+
+}
+
+void CombatManager::ResurrectNighthawks()
+{
+    unsigned blackslayers = 0;
+    for (const auto& combatant : mCombatants)
+    {
+        if (combatant.mCharacter && combatant.mCharacter->GetMonsterIndex() == BAK::sBlackslayer)
+        {
+            blackslayers++;
+        }
+    }
+
+    if (blackslayers == 0)
+    {
+        return;
+    }
+
+    for (auto& combatant : mCombatants)
+    {
+        if (!combatant.mCharacter)
+        {
+            continue;
+        }
+
+        if (combatant.IsExorcised() || !combatant.IsDead())
+        {
+            continue;
+        }
+
+        auto monsterIndex = combatant.mCharacter->GetMonsterIndex();
+
+        if (!(monsterIndex == BAK::sBlackslayer || monsterIndex == BAK::sNighthawk))
+        {
+            continue;
+        }
+
+        // ResurrectCombatant
+    }
+}
+
+void CombatManager::TickCombatEffectsAtEndOfTurn()
+{
+    for (auto& combatant : mCombatants)
+    {
+        bool expiredCharacter = BAK::TickCombatEffects(combatant.mCombatState);
+        if (expiredCharacter)
+        {
+            // remove the combatant (illusion) from the combat
+        }
+    }
+}
+
+std::vector<Combatant>::iterator CombatManager::SelectNextCombatantForTurn(bool onlyPlayer)
+{
+    std::vector<Combatant>::iterator best = mCombatants.end();
+    std::optional<unsigned> bestSpeed;
+
+    for (auto it = mCombatants.begin(); it != mCombatants.end(); ++it)
+    {
+        if (!BAK::IsCombatantActive(it->mCombatState, true))
+        {
+            continue;
+        }
+
+        auto* character = it->mCharacter;
+        if (!character)
+        {
+            continue;
+        }
+
+        if (onlyPlayer && character->IsEnemy())
+        {
+            continue;
+        }
+
+        auto speed = character->GetSkill(BAK::SkillType::Speed);
+        if (speed == 0)
+        {
+            speed = 1;
+        }
+
+        if (!bestSpeed || speed >= *bestSpeed)
+        {
+            bestSpeed = speed;
+            best = it;
+        }
+    }
+
+    return best;
 }
 
 void CombatManager::ClearGrid()
@@ -556,155 +792,6 @@ void CombatManager::ClearGrid()
             gridCell.mState = 0;
         }
     }
-}
-
-void CombatManager::DamageCombatant(
-    Combatant& victim,
-    const int originalDamage,
-    bool useArmor,
-    bool damageTypeMelee,
-    std::uint16_t modifierFlags,
-    bool skipDirectDamage
-)
-{
-    assert(victim.mCharacter);
-
-    // Only killable using strength drain
-    if (victim.mMonster == BAK::sWindElemental)
-    {
-        return;
-    }
-
-    // The illusion characters don't take damage
-    if (BAK::GetSpellEffect(victim.mCombatState, BAK::sDannonsDelusions))
-    {
-        return;
-    }
-
-    if (victim.IsDead())
-    {
-        return;
-    }
-
-    if (originalDamage < 1)
-    {
-        return;
-    }
-
-    auto damage = originalDamage;
-
-    if (useArmor)
-    {
-        auto reduction = BAK::CalculateArmorReduction(*victim.mCharacter);
-        damage = damage * (100 - reduction) / 100;
-        if (damage <= 0)
-        {
-            damage = GetRandomNumber(1, 2);
-        }
-    }
-
-    auto* shieldEffect = BAK::GetSpellEffect(victim.mCombatState, BAK::sHochosHaven);
-    if (!skipDirectDamage && shieldEffect)
-    {
-        shieldEffect->mAmount -= damage;
-        damage= 0;
-
-        int shieldLeft = shieldEffect->mAmount;
-        if (shieldLeft < 0)
-        {
-            if (shieldLeft == 0x8000)
-            {
-                damage = 0x7FFF;
-            }
-            else
-            {
-                damage = -shieldLeft;
-            }
-        }
-
-        if (damage == 0)
-        {
-            return;
-        }
-    }
-
-    if (!skipDirectDamage)
-    {
-        auto* skinEffect = BAK::GetSpellEffect(victim.mCombatState, BAK::sSkinOfTheDragon);
-        {
-            damage = 0;
-        }
-    }
-
-    damage = BAK::CalculateMonsterWeakness(victim.mCharacter->GetMonsterIndex(), damage, modifierFlags);
-    damage = BAK::CalculateMonsterResistance(victim.mCharacter->GetMonsterIndex(), damage, modifierFlags);
-
-    if (damage > 0 && (modifierFlags & std::to_underlying(BAK::ModifierFlags::Poison)))
-    {
-        BAK::PoisonCombatant(*victim.mCharacter, victim.mCombatState);
-    }
-
-    auto& stamina = victim.mCharacter->GetSkills().GetSkill(BAK::SkillType::Stamina);
-    if (stamina.mTrueSkill < damage)
-    {
-        auto excessDamage = damage - stamina.mTrueSkill;
-        auto& health = victim.mCharacter->GetSkills().GetSkill(BAK::SkillType::Health);
-
-        if (health.mTrueSkill < excessDamage)
-        {
-            health.mTrueSkill = 0;
-        }
-        else
-        {
-            health.mTrueSkill -= excessDamage;
-        }
-    }
-    else
-    {
-        stamina.mTrueSkill -= damage;
-    }
-
-    if (originalDamage > 0 && damageTypeMelee != 0)
-    {
-        // Apply state 0x40;
-        // set state health display type to damage type
-        // set affeted by str drain = 2
-        unsigned displayDamage = 1;
-        if (originalDamage < 1000)
-        {
-            displayDamage = originalDamage;
-        }
-    }
-    else if (damageTypeMelee != 0)
-    {
-        unsigned displayDamage = 1;
-        // display hit text type = 0xf8
-    }
-
-    if ((modifierFlags & std::to_underlying(BAK::ModifierFlags::Fire)) != 0)
-    {
-        // do particle effects of flamecast color
-    }
-
-    if (modifierFlags & std::to_underlying(BAK::ModifierFlags::Frost))
-    {
-        // one shot combat effect 2
-    }
-
-    if (modifierFlags & std::to_underlying(BAK::ModifierFlags::Poison))
-    {
-        // one shot combat effect 0x13
-    }
-
-    auto& health = victim.mCharacter->GetSkills().GetSkill(BAK::SkillType::Health);
-    if (health.mTrueSkill == 0)
-    {
-        // called after death in combat
-        // combatState.mFlags ~= 0x10 -> remove exorcised attribute when die
-    }
-
-    // recalculates the skill values for health
-    victim.mCharacter->GetSkill(BAK::SkillType::TotalHealth);
 }
 
 }

--- a/game/combat/combatManager.cpp
+++ b/game/combat/combatManager.cpp
@@ -3,6 +3,7 @@
 #include "audio/audio.hpp"
 
 #include "bak/combat/types.hpp"
+#include "bak/monster.hpp"
 #include "game/combat/gridAlgorithms.hpp"
 
 #include "bak/combat/calculations.hpp"
@@ -255,7 +256,13 @@ void CombatManager::SetCurrentCombatant(bool onlyParty)
             continue;
         }
 
+        // Find best PC then find best AI
+        // then select between them to store some state for AI specifically..
         auto speed = character->GetSkill(BAK::SkillType::Speed);
+        if (speed == 0 || combatant.IsDead())
+        {
+            speed = 1;
+        }
 
         if (!bestSpeed || speed > *bestSpeed)
         {
@@ -427,8 +434,8 @@ void CombatManager::Execute(const Attack& attack)
 
     if (!isThrust)
     {
-        //damageCombatant(target, 1, false, false, true, false);
-        // attacker.StateFlags &= (~0x40) -- not sure what 0x40 is used for yet
+        DamageCombatant(target, 1, false, false, true, false);
+        // attacker.StateFlags &= (~0x40) // i.e. don't display the hit effect
     }
 
     if (attackResult == BAK::MeleeResult::Hit)
@@ -448,7 +455,7 @@ void CombatManager::Execute(const Attack& attack)
         bool damageTypeMelee = true;
         auto modifierFlags = BAK::GetMeleeModifierFlags(*me.mCharacter);
         bool skipDirectDamage = false;
-        //damageCombatant(target, damage, useArmor, damageTypeMelee, modifierFlags, skipDirectDamage);
+        DamageCombatant(target, damage, useArmor, damageTypeMelee, modifierFlags, skipDirectDamage);
     }
     else
     {
@@ -553,7 +560,7 @@ void CombatManager::ClearGrid()
 
 void CombatManager::DamageCombatant(
     Combatant& victim,
-    int damage,
+    const int originalDamage,
     bool useArmor,
     bool damageTypeMelee,
     std::uint16_t modifierFlags,
@@ -561,6 +568,30 @@ void CombatManager::DamageCombatant(
 )
 {
     assert(victim.mCharacter);
+
+    // Only killable using strength drain
+    if (victim.mMonster == BAK::sWindElemental)
+    {
+        return;
+    }
+
+    // The illusion characters don't take damage
+    if (BAK::GetSpellEffect(victim.mCombatState, BAK::sDannonsDelusions))
+    {
+        return;
+    }
+
+    if (victim.IsDead())
+    {
+        return;
+    }
+
+    if (originalDamage < 1)
+    {
+        return;
+    }
+
+    auto damage = originalDamage;
 
     if (useArmor)
     {
@@ -572,8 +603,37 @@ void CombatManager::DamageCombatant(
         }
     }
 
+    auto* shieldEffect = BAK::GetSpellEffect(victim.mCombatState, BAK::sHochosHaven);
+    if (!skipDirectDamage && shieldEffect)
+    {
+        shieldEffect->mAmount -= damage;
+        damage= 0;
+
+        int shieldLeft = shieldEffect->mAmount;
+        if (shieldLeft < 0)
+        {
+            if (shieldLeft == 0x8000)
+            {
+                damage = 0x7FFF;
+            }
+            else
+            {
+                damage = -shieldLeft;
+            }
+        }
+
+        if (damage == 0)
+        {
+            return;
+        }
+    }
+
     if (!skipDirectDamage)
     {
+        auto* skinEffect = BAK::GetSpellEffect(victim.mCombatState, BAK::sSkinOfTheDragon);
+        {
+            damage = 0;
+        }
     }
 
     damage = BAK::CalculateMonsterWeakness(victim.mCharacter->GetMonsterIndex(), damage, modifierFlags);
@@ -581,9 +641,70 @@ void CombatManager::DamageCombatant(
 
     if (damage > 0 && (modifierFlags & std::to_underlying(BAK::ModifierFlags::Poison)))
     {
-        //PoisonCombatant(victim);
+        BAK::PoisonCombatant(*victim.mCharacter, victim.mCombatState);
     }
-    // ...
+
+    auto& stamina = victim.mCharacter->GetSkills().GetSkill(BAK::SkillType::Stamina);
+    if (stamina.mTrueSkill < damage)
+    {
+        auto excessDamage = damage - stamina.mTrueSkill;
+        auto& health = victim.mCharacter->GetSkills().GetSkill(BAK::SkillType::Health);
+
+        if (health.mTrueSkill < excessDamage)
+        {
+            health.mTrueSkill = 0;
+        }
+        else
+        {
+            health.mTrueSkill -= excessDamage;
+        }
+    }
+    else
+    {
+        stamina.mTrueSkill -= damage;
+    }
+
+    if (originalDamage > 0 && damageTypeMelee != 0)
+    {
+        // Apply state 0x40;
+        // set state health display type to damage type
+        // set affeted by str drain = 2
+        unsigned displayDamage = 1;
+        if (originalDamage < 1000)
+        {
+            displayDamage = originalDamage;
+        }
+    }
+    else if (damageTypeMelee != 0)
+    {
+        unsigned displayDamage = 1;
+        // display hit text type = 0xf8
+    }
+
+    if ((modifierFlags & std::to_underlying(BAK::ModifierFlags::Fire)) != 0)
+    {
+        // do particle effects of flamecast color
+    }
+
+    if (modifierFlags & std::to_underlying(BAK::ModifierFlags::Frost))
+    {
+        // one shot combat effect 2
+    }
+
+    if (modifierFlags & std::to_underlying(BAK::ModifierFlags::Poison))
+    {
+        // one shot combat effect 0x13
+    }
+
+    auto& health = victim.mCharacter->GetSkills().GetSkill(BAK::SkillType::Health);
+    if (health.mTrueSkill == 0)
+    {
+        // called after death in combat
+        // combatState.mFlags ~= 0x10 -> remove exorcised attribute when die
+    }
+
+    // recalculates the skill values for health
+    victim.mCharacter->GetSkill(BAK::SkillType::TotalHealth);
 }
 
 }

--- a/game/combat/combatManager.hpp
+++ b/game/combat/combatManager.hpp
@@ -63,7 +63,6 @@ private:
 
     std::vector<Combatant> GetCombatants();
 
-    void SetCurrentCombatant(bool onlyParty);
     Combatant& GetCurrentCombatant();
 
     void ComputeGrid();
@@ -74,17 +73,18 @@ private:
     void ExecuteAction();
     void Execute(const Move&);
     void Execute(const Attack&);
+    void Execute(const AnimateDeath& death);
+
     void FinishTurn();
+    void StartNextTurn();
+    std::optional<BAK::CombatResult> CheckCombatFinished();
+    void ResurrectNighthawks();
+    void TickCombatEffectsAtEndOfTurn();
+    void SetCurrentCombatant(unsigned index);
+
+    std::vector<Combatant>::iterator SelectNextCombatantForTurn(bool onlyPlayer);
 
     void ClearGrid();
-    void DamageCombatant(
-        Combatant& victim,
-        int damage,
-        bool useArmor,
-        bool damageTypeMelee,
-        std::uint16_t modifierFlags,
-        bool skipDirectDamage
-    );
 
     std::vector<Combatant> mCombatants{};
 

--- a/game/combat/grid.hpp
+++ b/game/combat/grid.hpp
@@ -99,6 +99,7 @@ inline std::ostream& operator<<(std::ostream& os, const Grid& grid)
         }
         os << "\n";
     }
+    os << std::dec;
     return os;
 }
 

--- a/game/combat/types.cpp
+++ b/game/combat/types.cpp
@@ -2,7 +2,7 @@
 
 namespace Game::Combat {
 
-std::ostream& operator<<(std::ostream& os, Move move)
+std::ostream& operator<<(std::ostream& os, const Move& move)
 {
     return os << "Move {" << move.mTarget << "}";
 }
@@ -10,6 +10,11 @@ std::ostream& operator<<(std::ostream& os, Move move)
 std::ostream& operator<<(std::ostream& os, const Attack& attack)
 {
     return os << "Attack {" << attack.mTarget << ", " << attack.mType << "}";
+}
+
+std::ostream& operator<<(std::ostream& os, const AnimateDeath& animateDeath)
+{
+    return os << "AnimateDeath {" << animateDeath.mTarget << "}";
 }
 
 std::ostream& operator<<(std::ostream& os, const CombatAction& action)

--- a/game/combat/types.hpp
+++ b/game/combat/types.hpp
@@ -36,6 +36,8 @@ struct Combatant
     bool IsDefending() const { return mCombatState.mIsDefending; }
     bool& IsFleeing() { return mCombatState.mIsFleeing; }
     bool IsFleeing() const { return mCombatState.mIsFleeing; }
+    bool& IsExorcised() { return mCombatState.mIsExorcised; }
+    bool IsExorcised() const { return mCombatState.mIsExorcised; }
 };
 
 enum class StateFlags
@@ -60,12 +62,20 @@ struct Attack
     BAK::AttackType mType;
 };
 
+struct AnimateDeath
+{
+    GridPos mTarget;
+};
+
 using CombatAction = std::variant<
     Move,
-    Attack>;
+    Attack,
+    AnimateDeath
+    >;
 
-std::ostream& operator<<(std::ostream& os, Move move);
-std::ostream& operator<<(std::ostream& os, const Attack& attack);
-std::ostream& operator<<(std::ostream& os, const CombatAction& action);
+std::ostream& operator<<(std::ostream& os, const Move&);
+std::ostream& operator<<(std::ostream& os, const Attack&);
+std::ostream& operator<<(std::ostream& os, const AnimateDeath&);
+std::ostream& operator<<(std::ostream& os, const CombatAction&);
 
 }

--- a/game/gameRunner.cpp
+++ b/game/gameRunner.cpp
@@ -447,6 +447,13 @@ void GameRunner::RestoreCameraAfterCombat()
     mCamera.SetPosition(mSavedCameraPos);
 }
 
+void GameRunner::CombatFinished(BAK::CombatResult result)
+{
+    // Yuck... we probably don't need to go in and then back
+    // here to exit combat...
+    mGuiManager.ExitCombat(result);
+}
+
 void GameRunner::CombatCompleted(BAK::CombatResult result)
 {
     auto onReturn = ScopeGuard{[this]{
@@ -456,13 +463,13 @@ void GameRunner::CombatCompleted(BAK::CombatResult result)
         LoadWorldActors();
     }};
 
-    mLogger.Debug() << __FUNCTION__ << " " << ToString(result) << "\n";
+    mLogger.Debug() << __FUNCTION__ << " " << ToString(result.mOutcome) << "\n";
     ASSERT(mActiveEncounter);
     ASSERT(std::holds_alternative<BAK::Encounter::Combat>(mActiveEncounter->GetEncounter()));
     const auto& encounter = *mActiveEncounter;
     const auto& combat = std::get<BAK::Encounter::Combat>(encounter.GetEncounter());
 
-    if (result == BAK::CombatResult::Fled)
+    if (result.mOutcome == BAK::CombatOutcome::Fled)
     {
         const auto& retreatPos = BAK::Encounter::GetRetreatPosition(
             combat, mRetreatDirection);
@@ -480,7 +487,7 @@ void GameRunner::CombatCompleted(BAK::CombatResult result)
         mEncounterHandler.StartDialog(BAK::DialogSources::mRetreatSuccessful, true);
         return;
     }
-    else if (result == BAK::CombatResult::Won)
+    else if (result.mOutcome == BAK::CombatOutcome::Won)
     {
         mEncounterHandler.GetCombatHandler().UpdatePostEncounterFlags(encounter, combat);
 
@@ -527,31 +534,7 @@ void GameRunner::CombatCompleted(BAK::CombatResult result)
         }
         else
         {
-            if (true) // multiple combatants killed
-            {
-                //if (MonstersWereGhosts)
-                //{
-                //    mEncounterHandler.StartDialog(BAK::DialogSources::mWonVersusGhosts, true);
-                //}
-                if (BAK::IsSpecialBattle(combat.mCombatIndex))
-                {
-                    mEncounterHandler.StartDialog(BAK::DialogSources::mWonSpecialBattle, true);
-                }
-                else
-                {
-                    mEncounterHandler.StartDialog(BAK::DialogSources::mWonBattle, true);
-                }
-            }
-            else // if (OneMonsterInCombat && IsGhost)
-            {
-                mEncounterHandler.StartDialog(BAK::DialogSources::mWonVersusGhost, true);
-            }
-            // else if (OneMonsterInCombat && !IsGhost)
-            // mEncounterHandler.StartDialog(BAK::DialogSources::mDefeatedOneEnemy, true);
-            // else if (NoCombatantsRemaining && IsTrap)
-            // mEncounterHandler.StartDialog(BAK::DialogSources::mSolvedTrap, true);
-            // else if (NoCombatantsRemaining)
-            // mEncounterHandler.StartDialog(BAK::DialogSources::mEnemyFled, true);
+            mEncounterHandler.StartDialog(result.mDialog, true);
         }
     }
 }
@@ -704,7 +687,11 @@ void GameRunner::RunGameUpdate(bool advanceTime)
 
 void GameRunner::SetHoveredEntity(std::optional<BAK::EntityIndex> entityId)
 {
-    if (entityId == mHoveredEntity) return;
+    if (entityId == mHoveredEntity || mAnimationActive)
+    {
+        return;
+    }
+
     mHoveredEntity = entityId;
     if (mCombatManager.IsCombatActive() && entityId)
     {
@@ -875,15 +862,30 @@ void GameRunner::SetCombatantDirection(
     actor->SetDirection(direction);
 }
 
-void GameRunner::AnimateCombatant(
-    BAK::EntityIndex entityId)
+void GameRunner::SetCombatantUpdateIdle(
+    BAK::EntityIndex entityId,
+    bool update)
 {
     auto* actor = mCombatActorStore.GetActor(entityId);
     assert(actor);
-    mLogger.Debug() << "Animating combatant: " << entityId 
+    actor->SetUpdateIdle(false);
+}
+
+void GameRunner::AnimateCombatant(
+    BAK::EntityIndex entityId)
+{
+    AnimateCombatant(entityId, []{});
+}
+
+void GameRunner::AnimateCombatant(
+    BAK::EntityIndex entityId,
+    std::function<void()> onFinished)
+{
+    auto* actor = mCombatActorStore.GetActor(entityId);
+    assert(actor);
+    mLogger.Debug() << "Animating combatant (with callback): " << entityId 
         << " mid: " << actor->mMonster << "\n";
 
-    // This might fail when we're doing crossbow I think?
     assert(BAK::IsCardinal(actor->mDirection));
 
     auto frameTime = sFrameTime * mAnimationSpeedMultiplier;
@@ -893,8 +895,9 @@ void GameRunner::AnimateCombatant(
         std::make_unique<Combat::FrameAnimator>(
             *actor,
             frameTime,
-            [this]() mutable {
+            [this, finished=std::move(onFinished)]() mutable {
                 mAnimationActive = false;
+                finished();
             }));
 }
 

--- a/game/gameRunner.hpp
+++ b/game/gameRunner.hpp
@@ -98,12 +98,23 @@ public:
         BAK::EntityIndex entityId,
         BAK::Direction direction) override;
 
+    void SetCombatantUpdateIdle(
+        BAK::EntityIndex entityId,
+        bool update) override;
+
     void AnimateCombatant(
         BAK::EntityIndex entityId) override;
+
+    void AnimateCombatant(
+        BAK::EntityIndex entityId,
+        std::function<void()> onFinished) override;
 
     void AnimateAttack(
         BAK::EntityIndex entityId,
         glm::uvec2 targetGrid) override;
+
+    void CombatFinished(
+        BAK::CombatResult) override;
 
     const Graphics::RenderData& GetZoneRenderData() const;
     void OnTimeDelta(double timeDelta);

--- a/gui/combat/combatScreen.cpp
+++ b/gui/combat/combatScreen.cpp
@@ -253,12 +253,12 @@ void CombatScreen::HandleButton(unsigned buttonIndex)
 
 void CombatScreen::ExitCombat()
 {
-    mGuiManager.ExitCombat(BAK::CombatResult::Won);
+    mGuiManager.ExitCombat(BAK::CombatResult{BAK::CombatOutcome::Won});
 }
 
 void CombatScreen::Retreat()
 {
-    mGuiManager.ExitCombat(BAK::CombatResult::Fled);
+    mGuiManager.ExitCombat(BAK::CombatResult{BAK::CombatOutcome::Fled});
 }
 
 void CombatScreen::AddChildren()

--- a/gui/guiManager.hpp
+++ b/gui/guiManager.hpp
@@ -138,6 +138,8 @@ public:
 
     void SetCombatSequenceActive(bool isActive) override { mCombatSequenceActive = isActive; }
     bool GetCombatSequenceActive() { return mCombatSequenceActive; }
+    FontManager& GetFontManager() { return mFontManager; }
+    const FontManager& GetFontManager() const { return mFontManager; }
     void PopOnExitCallback(OnExit action);
 
     void SetCombatManager(BAK::ICombatManager& combatManager) override;


### PR DESCRIPTION
Melee damage is now applied correctly in combat.
When combatants die it is animated.
When you win or lose the combat the game reflects that appropriately.