### PR TITLE
Issue #306 - Height interpolation on bridges

### DIFF
--- a/app/main3d.cpp
+++ b/app/main3d.cpp
@@ -549,21 +549,17 @@ int main(int argc, char** argv)
         {
             auto proposed = camera.GetPendingPosition();
             auto bakPos = glm::uvec2{proposed.x, -proposed.z};
-            if (gameRunner.CannotMoveHere(bakPos))
+            if (gameRunner.CannotMoveHere(bakPos) && gameRunner.GetClipEnabled())
             {
-                if (gameRunner.GetClipEnabled())
-                {
-                    camera.RejectPendingMove();
-                }
-                else
-                {
-                    camera.AcceptPendingMove();
-                    UpdateGameTile();
-                }
+                camera.RejectPendingMove();
             }
             else
             {
                 camera.AcceptPendingMove();
+                if (auto height = gameRunner.ComputeTerrainHeight(camera.GetGameLocation().mPosition))
+                {
+                    camera.SetHeight(*height);
+                }
                 UpdateGameTile();
             }
         }

--- a/bak/camera.cpp
+++ b/bak/camera.cpp
@@ -87,6 +87,12 @@ void Camera::SetPosition(const glm::vec3& position)
     mDistanceTravelled = 0;
 }
 
+void Camera::SetHeight(float height)
+{
+    mPosition.y = height;
+    PositionChanged();
+}
+
 void Camera::SetAngle(glm::vec2 angle)
 {
     mAngle = angle;

--- a/bak/camera.hpp
+++ b/bak/camera.hpp
@@ -24,6 +24,7 @@ public:
     BAK::GamePositionAndHeading GetGameLocation() const;
     glm::uvec2 GetGameTile() const;
     void SetPosition(const glm::vec3& position);
+    void SetHeight(float height);
     void SetAngle(glm::vec2 angle);
     BAK::GameHeading GetHeading();
     void SetDeltaTime(double dt);

--- a/bak/collision.cpp
+++ b/bak/collision.cpp
@@ -4,46 +4,51 @@
 #include "bak/worldFactory.hpp"
 #include "graphics/glm.hpp"
 
+#include <glm/common.hpp>
 #include <glm/geometric.hpp>
+#include <glm/gtc/type_ptr.hpp>
 #include <glm/gtx/rotate_vector.hpp>
 
 #include <cmath>
+#include <limits>
 
 namespace BAK {
 
 // Assumes the point is already in model clip space
-bool PointInModelClip(glm::vec2 point, const ModelClip& clip)
+bool PointInClipElement(glm::vec2 point, const ClipElement& element)
 {
     constexpr float epsilon = 1e-5f;
 
+    for (const auto& elemPoint : element.mPoints)
+    {
+        auto dir = point - glm::cast<float>(elemPoint.mXY);
+        auto normal = glm::normalize(glm::cast<float>(elemPoint.mNormal));
+        auto dot = glm::dot(dir, normal);
+        if (dot > epsilon)
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool PointInModelClip(glm::vec2 point, const ModelClip& clip)
+{
     if (std::abs(point.x) > clip.mRadius.x || std::abs(point.y) > clip.mRadius.y)
     {
         return false;
     }
 
-    bool anyWithin = false;
     for (const auto& elem : clip.mElements)
     {
-        bool allWithin = true;
-        for (const auto& elemPoint: elem.mPoints)
-        {
-            auto dir = point - glm::cast<float>(elemPoint.mXY);
-            // TODO: Normalise it in intermediate object...
-            auto normal = glm::normalize(glm::cast<float>(elemPoint.mNormal));
-            auto dot = glm::dot(dir, normal);
-            if (dot > epsilon)
-            {
-                allWithin = false;
-            }
-        }
-
-        if (allWithin)
+        if (PointInClipElement(point, elem))
         {
             return true;
         }
     }
 
-    return anyWithin;
+    return false;
 }
 
 bool BlocksMovement(const ZoneItem& item)
@@ -84,7 +89,7 @@ bool AllowsMovement(const ZoneItem& item)
         switch (item.GetEntityType())
         {
         case EntityType::EXTERIOR: return true;
-        default: return false;
+        default: break;
         }
     }
 
@@ -97,7 +102,61 @@ bool AllowsMovement(const ZoneItem& item)
     return false;
 }
 
-glm::vec2 WorldToModelClipSpace(glm::vec2 playerPos, glm::vec2 itemPos, float rotation, float scale)
+std::optional<float> ComputeHeight(
+    glm::vec2 modelClipPos,
+    const ClipElement& element)
+{
+    if (!element.mHeightPoint)
+    {
+        return std::nullopt;
+    }
+
+    const glm::vec2 heightDirection = glm::vec2(element.mHeightPoint->mNormal);
+    const glm::vec2 referencePoint = glm::vec2(element.mHeightPoint->mXY);
+
+    if (heightDirection == glm::vec2{0, 0})
+    {
+        return static_cast<float>(element.mBaseHeight);
+    }
+
+    const float slopeDistance = glm::dot(heightDirection, referencePoint - modelClipPos);
+    const float height = static_cast<float>(element.mBaseHeight)
+        + (slopeDistance * static_cast<float>(element.mScale)) / 4096.0f;
+
+    return height;
+}
+
+std::optional<float> ComputeHeight(
+    glm::vec2 modelClipPos,
+    const ModelClip& clip)
+{
+    for (std::size_t i = 0; i < clip.mElements.size(); ++i)
+    {
+        if (PointInClipElement(modelClipPos, clip.mElements[i]))
+        {
+            auto height = ComputeHeight(modelClipPos, clip.mElements[i]);
+            if (height)
+            {
+                return *height;
+            }
+            return std::nullopt;
+        }
+    }
+    return std::nullopt;
+}
+
+float ComputeWorldHeight(
+    float height,
+    float itemScale)
+{
+    return BAK::gBakCameraHeight + height * itemScale;
+}
+
+glm::vec2 WorldToModelClipSpace(
+    glm::vec2 playerPos,
+    glm::vec2 itemPos,
+    float rotation,
+    float scale)
 {
     auto local = playerPos - itemPos;
     auto rotated = (rotation != 0.0f)

--- a/bak/collision.hpp
+++ b/bak/collision.hpp
@@ -2,14 +2,35 @@
 
 #include <glm/glm.hpp>
 
+#include <optional>
+
 namespace BAK {
 
+struct ClipElement;
 struct ModelClip;
 class ZoneItem;
 
+bool PointInClipElement(glm::vec2 point, const ClipElement& element);
 bool PointInModelClip(glm::vec2 point, const ModelClip&);
 bool BlocksMovement(const ZoneItem&);
 bool AllowsMovement(const ZoneItem&);
-glm::vec2 WorldToModelClipSpace(glm::vec2 playerPos, glm::vec2 itemPos, float rotation, float scale);
+
+std::optional<float> ComputeHeight(
+    glm::vec2 modelClipPos,
+    const ClipElement& element);
+
+std::optional<float> ComputeHeight(
+    glm::vec2 modelClipPos,
+    const ModelClip& clip);
+
+float ComputeWorldHeight(
+    float height,
+    float itemScale);
+
+glm::vec2 WorldToModelClipSpace(
+    glm::vec2 playerPos,
+    glm::vec2 itemPos,
+    float rotation,
+    float scale);
 
 }

--- a/bak/combat/calculations.cpp
+++ b/bak/combat/calculations.cpp
@@ -637,8 +637,8 @@ void PoisonCombatant(Character& combatant, CombatState& state)
         auto health = skills.GetSkill(SkillType::Health);
         auto stamina = skills.GetSkill(SkillType::Stamina);
 
-        Logging::LogDebug(__FUNCTION__) << " Dead: " << combatState.mIsDead << " Before: \nHealth "
-            << health << "\nStamina " << stamina << "\n";
+        Logging::LogDebug(__FUNCTION__) << "Mods: " << std::hex << modifierFlags << std::dec
+            << " Before: \nHealth " << health << "\nStamina " << stamina << "\n";
     }
 
     if (monster == sWindElemental)

--- a/bak/gameState.cpp
+++ b/bak/gameState.cpp
@@ -28,6 +28,7 @@
 #include "bak/spells.hpp"
 #include "bak/state/dialog.hpp"
 #include "bak/dialogAction.hpp"
+#include "bak/zone.hpp"
 #include "bak/time.hpp"
 
 #include "com/ostream.hpp"
@@ -186,6 +187,11 @@ MapLocation GameState::GetMapLocation() const
 ZoneNumber GameState::GetZone() const
 {
     return mGameData.mLocation.mZone;
+}
+
+bool GameState::IsUnderground() const
+{
+    return BAK::IsUnderground(GetZone());
 }
 
 const WorldClock& GameState::GetWorldTime() const

--- a/bak/gameState.hpp
+++ b/bak/gameState.hpp
@@ -102,6 +102,7 @@ public:
     GamePositionAndHeading GetLocation() const;
     MapLocation GetMapLocation() const;
     ZoneNumber GetZone() const;
+    bool IsUnderground() const;
 
     auto& GetTimeExpiringState() { return mTimeExpiringState; }
 

--- a/bak/test/collisionTest.cpp
+++ b/bak/test/collisionTest.cpp
@@ -204,4 +204,162 @@ TEST_F(CollisionTestFixture, WorldToModelClipSpaceNonZeroModelPosWithRotationAnd
     EXPECT_NEAR(result.y, -10.0f, 1e-6f);
 }
 
+TEST_F(CollisionTestFixture, PointInClipElementBasic)
+{
+    // Square from (-100,-100) to (100,100)
+    // Each vertex normal is the outward-facing normal of the edge leaving it
+    ClipElement elem{};
+    elem.mPoints = {
+        ClipPoint{{  0, -100}, {-100, -100}},  // bottom edge, normal down
+        ClipPoint{{ 100,    0}, { 100, -100}},  // right edge, normal right
+        ClipPoint{{   0,  100}, { 100,  100}},  // top edge, normal up
+        ClipPoint{{-100,    0}, {-100,  100}},  // left edge, normal left
+    };
+    elem.mHeightPoint = std::nullopt;
+    elem.mScale = 0;
+    elem.mBaseHeight = 0;
+
+    EXPECT_TRUE(PointInClipElement({0, 0}, elem));
+    EXPECT_TRUE(PointInClipElement({50, 0}, elem));
+    EXPECT_FALSE(PointInClipElement({200, 0}, elem));
+    EXPECT_FALSE(PointInClipElement({0, 200}, elem));
+}
+
+TEST_F(CollisionTestFixture, ComputeHeightNoHeightPoint)
+{
+    ClipElement elem{};
+    elem.mPoints = {
+        ClipPoint{{-100, -100}, {-100, -100}},
+        ClipPoint{{   0, -100}, { 100, -100}},
+        ClipPoint{{ 100,    0}, { 100,  100}},
+        ClipPoint{{   0,  100}, {   0,  100}},
+    };
+    elem.mHeightPoint = std::nullopt;
+    elem.mScale = 0;
+    elem.mBaseHeight = 0;
+
+    auto result = ComputeHeight({0, 0}, elem);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(CollisionTestFixture, ComputeHeightVertexBased)
+{
+    ClipElement elem{};
+    elem.mPoints = {
+        ClipPoint{{-100, -100}, {-100, -100}},
+        ClipPoint{{   0, -100}, { 100, -100}},
+        ClipPoint{{ 100,    0}, { 100,  100}},
+        ClipPoint{{   0,  100}, {   0,  100}},
+    };
+    elem.mHeightPoint = ClipPoint{
+        glm::ivec2{0, 0},
+        glm::ivec2{0, 0}
+    };
+    elem.mScale = 0;
+    elem.mBaseHeight = 500;
+
+    auto result = ComputeHeight({0, 0}, elem);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_FLOAT_EQ(*result, 500.0f);
+}
+
+TEST_F(CollisionTestFixture, ComputeHeightEdgeBasedAtReference)
+{
+    ClipElement elem{};
+    elem.mPoints = {
+        ClipPoint{{-100, -100}, {-100, -100}},
+        ClipPoint{{   0, -100}, { 100, -100}},
+        ClipPoint{{ 100,    0}, { 100,  100}},
+        ClipPoint{{   0,  100}, {   0,  100}},
+    };
+    // Direction (1, 0), reference at (50, 0)
+    elem.mHeightPoint = ClipPoint{
+        glm::ivec2{1, 0},
+        glm::ivec2{50, 0}
+    };
+    elem.mScale = 4;
+    elem.mBaseHeight = 200;
+
+    // At the reference point, dot = 0, so raw = baseHeight
+    auto result = ComputeHeight({50, 0}, elem);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_FLOAT_EQ(*result, 200.0f);
+}
+
+TEST_F(CollisionTestFixture, ComputeHeightEdgeBasedGradient)
+{
+    ClipElement elem{};
+    elem.mPoints = {
+        ClipPoint{{-100, -100}, {-100, -100}},
+        ClipPoint{{   0, -100}, { 100, -100}},
+        ClipPoint{{ 100,    0}, { 100,  100}},
+        ClipPoint{{   0,  100}, {   0,  100}},
+    };
+    // Direction (1, 0), reference at (0, 0), scale=4, baseHeight=100
+    elem.mHeightPoint = ClipPoint{
+        glm::ivec2{1, 0},
+        glm::ivec2{0, 0}
+    };
+    elem.mScale = 4;
+    elem.mBaseHeight = 100;
+
+    auto result = ComputeHeight({-10, 0}, elem);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_NEAR(*result, 100.0f + 40.0f / 4096.0f, 1e-4f);
+}
+
+TEST_F(CollisionTestFixture, ComputeHeightFindsCorrectElement)
+{
+    // elem0: square from (-100,-100) to (100,100), no height data
+    ClipElement elem0{};
+    elem0.mPoints = {
+        ClipPoint{{  0, -100}, {-100, -100}},
+        ClipPoint{{ 100,    0}, { 100, -100}},
+        ClipPoint{{   0,  100}, { 100,  100}},
+        ClipPoint{{-100,    0}, {-100,  100}},
+    };
+    elem0.mHeightPoint = std::nullopt;
+    elem0.mScale = 0;
+    elem0.mBaseHeight = 0;
+
+    // elem1: square from (-200,-200) to (-100,-100), has height
+    ClipElement elem1{};
+    elem1.mPoints = {
+        ClipPoint{{  0, -100}, {-200, -200}},
+        ClipPoint{{ 100,    0}, {-100, -200}},
+        ClipPoint{{   0,  100}, {-100, -100}},
+        ClipPoint{{-100,    0}, {-200, -100}},
+    };
+    elem1.mHeightPoint = ClipPoint{
+        glm::ivec2{0, 0},
+        glm::ivec2{0, 0}
+    };
+    elem1.mScale = 0;
+    elem1.mBaseHeight = 777;
+
+    ModelClip clip{};
+    clip.mRadius = {16000, 16000};
+    clip.mFlags = 0;
+    clip.mWalkable = false;
+    clip.mHasVertical = false;
+    clip.mElements = {elem0, elem1};
+    clip.mName = "test";
+
+    // Point in elem0 (no height)
+    auto r0 = ComputeHeight({0, 0}, clip);
+    EXPECT_FALSE(r0.has_value());
+
+    // Point in elem1 (has height)
+    auto r1 = ComputeHeight({-150, -150}, clip);
+    ASSERT_TRUE(r1.has_value());
+    EXPECT_FLOAT_EQ(*r1, 777.0f);
+}
+
+TEST_F(CollisionTestFixture, ComputeWorldHeightScale)
+{
+    EXPECT_FLOAT_EQ(ComputeWorldHeight(10.0f, 4.0f), 140.0f);
+    EXPECT_FLOAT_EQ(ComputeWorldHeight(0.0f, 1.0f), 100.0f);
+    EXPECT_FLOAT_EQ(ComputeWorldHeight(-5.0f, 2.0f), 90.0f);
+}
+
 }

--- a/game/gameRunner.cpp
+++ b/game/gameRunner.cpp
@@ -147,6 +147,10 @@ void GameRunner::LoadZoneData(BAK::ZoneNumber zone)
         mZoneData->mZoneTextures.GetMaxDim());
     LoadSystems();
     mCamera.SetGameLocation(mGameState.GetLocation());
+    if (auto height = ComputeTerrainHeight(mGameState.GetLocation().mPosition))
+    {
+        mCamera.SetHeight(*height);
+    }
 }
 
 void GameRunner::DoTransition(
@@ -631,7 +635,7 @@ void GameRunner::SetupCombatCamera(const BAK::Encounter::Encounter&)
     auto heading = mCamera.GetGameAngle();
     auto angle = mCamera.GetAngle();
 
-    bool isUnderground = BAK::IsUnderground(mGameState.GetZone());
+    bool isUnderground = mGameState.IsUnderground();
 
     angle.x = BAK::ToGlAngle(heading).x;
     angle.y = isUnderground ? BAK::gBakCombatCameraDownAngleUnderground : BAK::gBakCombatCameraDownAngle;
@@ -961,7 +965,62 @@ bool GameRunner::CannotMoveHere(BAK::GamePosition playerPos) const
         }
     }
 
-    return mFollowRoad || BAK::IsUnderground(mGameState.GetZone());
+    return mFollowRoad || mGameState.IsUnderground();
+}
+
+std::optional<float> GameRunner::ComputeTerrainHeight(BAK::GamePosition playerPos) const
+{
+    if (!mZoneData)
+    {
+        return std::nullopt;
+    }
+
+    struct Candidate {
+        const BAK::WorldItemInstance* mItem;
+        float mDistSq;
+    };
+    std::vector<Candidate> candidates;
+
+    for (const auto& world : mZoneData->mWorldTiles.GetTiles())
+    {
+        for (const auto& item : world.GetItems())
+        {
+            const auto& zoneItem = item.GetZoneItem();
+            if (!BAK::AllowsMovement(zoneItem) || !zoneItem.GetModelClip())
+            {
+                continue;
+            }
+
+            const auto itemPos = item.GetLocation();
+            const float dx = static_cast<float>(playerPos.x) - itemPos.x;
+            const float dy = static_cast<float>(playerPos.y) + itemPos.z;
+            candidates.push_back({&item, dx*dx + dy*dy});
+        }
+    }
+
+    std::sort(candidates.begin(), candidates.end(),
+        [](const auto& a, const auto& b) { return a.mDistSq < b.mDistSq; });
+
+    for (const auto& c : candidates)
+    {
+        const auto& item = *c.mItem;
+        const auto& zoneItem = item.GetZoneItem();
+        const auto& modelClip = *zoneItem.GetModelClip();
+
+        auto modelSpace = BAK::WorldToModelClipSpace(
+            glm::vec2{playerPos},
+            glm::vec2{item.GetBakLocation()},
+            item.GetRotation().y,
+            zoneItem.GetScale());
+
+        auto height = BAK::ComputeHeight(modelSpace, modelClip);
+        if (height)
+        {
+            return BAK::ComputeWorldHeight(*height, zoneItem.GetScale());
+        }
+    }
+
+    return std::nullopt;
 }
 
 void GameRunner::RunGameUpdate(bool advanceTime)

--- a/game/gameRunner.hpp
+++ b/game/gameRunner.hpp
@@ -107,6 +107,7 @@ public:
     void SetClipEnabled(bool clip) { mClipEnabled = clip; }
     bool GetClipEnabled() const { return mClipEnabled; }
     bool CannotMoveHere(BAK::GamePosition playerPos) const;
+    std::optional<float> ComputeTerrainHeight(BAK::GamePosition playerPos) const;
     std::optional<BAK::DoorIndex> GetDoorIndex(glm::uvec2 bakLocation) const;
     void OnDoorStateChanged(BAK::DoorIndex doorIndex, bool isOpen);
     void SetFollowRoad(bool follow) { mFollowRoad = follow; }


### PR DESCRIPTION
bridge1,2 GID items have a height element that determines the height of the player as they travel along the bridge. Use this to modify player height when they are colliding with a bridge.