### PR TITLE
Issue #309 - Implement snap to road

### DIFF
--- a/bak/constants.hpp
+++ b/bak/constants.hpp
@@ -11,6 +11,7 @@ static constexpr float gWorldScale = 100.;
 
 static constexpr float gTileSize = 64000.;
 static constexpr auto gCellSize = 1600;
+static constexpr auto gHalfCellSize = gCellSize / 2;
 static constexpr auto gRotationSearchAmount = 100.0f;
 
 static constexpr auto gCombatGridCellSize = 300;

--- a/bak/movement.cpp
+++ b/bak/movement.cpp
@@ -1,6 +1,11 @@
 #include "bak/movement.hpp"
 
+#include "bak/constants.hpp"
 #include "bak/coordinates.hpp"
+
+#include "com/logger.hpp"
+
+#include "graphics/glm.hpp"
 
 #include <cmath>
 
@@ -65,6 +70,42 @@ SlideProjection ProjectSlide(
     return SlideProjection{
         projected,
         GamePosition{glm::uvec2{projectedPos.x, -projectedPos.z}}};
+}
+
+GamePosition SnapPositionToCellCenter(GamePosition pos)
+{
+    const auto snapAxis = [](unsigned value) {
+        const auto cell = std::max<int>(
+            0,
+            std::lround((static_cast<double>(value) - gHalfCellSize) / gCellSize));
+        return static_cast<unsigned>(cell) * gCellSize + gHalfCellSize;
+    };
+
+    return GamePosition{
+        glm::uvec2{
+            snapAxis(pos.x),
+            snapAxis(pos.y)}};
+}
+
+GamePosition FindNearestRoadCell(
+    GamePosition pos,
+    std::function<bool(GamePosition)> isOnRoad)
+{
+    constexpr glm::vec2 sCellOffsets[] = {
+        { 0,  0}, { 1,  0}, {-1,  0},
+        { 0,  1}, { 0, -1}, { 1,  1},
+        {-1,  1}, { 1, -1}, {-1, -1}};
+
+    for (const auto& offset : sCellOffsets)
+    {
+        const auto candidate = SnapPositionToCellCenter(
+            pos + glm::uvec2{offset * static_cast<float>(gCellSize)});
+        if (isOnRoad(candidate))
+        {
+            return candidate;
+        }
+    }
+    return pos;
 }
 
 }

--- a/bak/movement.hpp
+++ b/bak/movement.hpp
@@ -5,6 +5,7 @@
 #include <glm/glm.hpp>
 
 #include <cstdint>
+#include <functional>
 
 namespace BAK {
 
@@ -29,5 +30,11 @@ SlideProjection ProjectSlide(
     float maxDistance);
 
 CardinalDirection GetRotationDirection(GameHeading currentHeading, GameHeading targetHeading);
+
+GamePosition SnapPositionToCellCenter(GamePosition);
+
+GamePosition FindNearestRoadCell(
+    GamePosition pos,
+    std::function<bool(GamePosition)> isOnRoad);
 
 }

--- a/game/gameRunner.cpp
+++ b/game/gameRunner.cpp
@@ -108,10 +108,7 @@ GameRunner::GameRunner(
 
     mGuiManager.SetCombatManager(mCombatManager);
     mGuiManager.SetToggleFollowRoadCallback(
-        [this]{
-            mGameState.SetFollowRoad(!mGameState.GetFollowRoad());
-            mGuiManager.SetFollowRoadActive(mGameState.GetFollowRoad());
-        });
+        [this]{ ToggleFollowRoad(); });
 
     mGlyphStore.Init(mGuiManager.GetFontManager().GetGameFont());
 }
@@ -1016,6 +1013,20 @@ void GameRunner::SetFollowRoadButtonVisible(bool visible)
     if (visible)
     {
         mGuiManager.SetFollowRoadActive(mGameState.GetFollowRoad());
+    }
+}
+void GameRunner::ToggleFollowRoad()
+{
+    mGameState.SetFollowRoad(!mGameState.GetFollowRoad());
+    mGuiManager.SetFollowRoadActive(mGameState.GetFollowRoad());
+
+    if (mGameState.GetFollowRoad())
+    {
+        auto location = mCamera.GetGameLocation();
+        location.mPosition = BAK::FindNearestRoadCell(
+            location.mPosition,
+            [this](BAK::GamePosition pos) { return IsOnRoad(pos); });
+        mCamera.SetGameLocation(location);
     }
 }
 

--- a/game/gameRunner.hpp
+++ b/game/gameRunner.hpp
@@ -110,6 +110,7 @@ public:
     bool CannotMoveHere(BAK::GamePosition playerPos) const;
     bool IsOnRoad(BAK::GamePosition playerPos) const;
     void SetFollowRoadButtonVisible(bool visible);
+    void ToggleFollowRoad();
     std::optional<float> ComputeTerrainHeight(BAK::GamePosition playerPos) const;
     std::optional<BAK::GameHeading> GetOpenDirection(BAK::GamePositionAndHeading playerLocation) const;
     std::optional<BAK::DoorIndex> GetDoorIndex(glm::uvec2 bakLocation) const;


### PR DESCRIPTION
BaK snaps the player to the center of the road rather than just enabling follow road mode.

All roads centers align with cell centers and all movement is along the center of the road, not allowing arbitrary movement within the road.