### PR TITLE
Issue #239 - Refactor audio manager threading to be safer

### DIFF
--- a/audio/audio.cpp
+++ b/audio/audio.cpp
@@ -5,7 +5,9 @@
 #include "com/visit.hpp"
 
 #include "SDL_mixer.h"
+
 #include <mutex>
+#include <utility>
 
 namespace AudioA {
 
@@ -60,25 +62,8 @@ IAudioManager& GetAudioManager()
 
 AudioManager::AudioManager()
 :
-    mRunning{true},
-    mQueueMutex{},
-    mQueuePlayThread{[this]{
-        using namespace std::chrono_literals;
-        while (mRunning)
-        {
-            std::this_thread::sleep_for(10ms);
-            std::lock_guard<std::mutex> lock(mQueueMutex);
-            if (!mSoundPlaying && !mSoundQueue.empty())
-            {
-                auto sound = mSoundQueue.front();
-                mSoundQueue.pop();
-                PlaySoundImpl(sound);
-            }
-        }
-    }},
     mLogger{Logging::LogState::GetLogger("AudioManager")}
 {
-    std::lock_guard<std::mutex> lock(mQueueMutex);
     if (SDL_Init(SDL_INIT_AUDIO) < 0)
     {
         mLogger.Error() << "Couldn't initialize SDL: "
@@ -92,14 +77,18 @@ AudioManager::AudioManager()
     }
 
     Mix_VolumeMusic(sAudioVolume);
-    //Mix_SetMidiPlayer(MIDI_ADLMIDI);
     Mix_SetMidiPlayer(MIDI_OPNMIDI);
-    //Mix_SetMidiPlayer(MIDI_Fluidsynth);
+
+    mAudioThread = std::thread{[this]{ AudioLoop(); }};
 }
 
 AudioManager& AudioManager::Get()
 {
-    assert(sStaticAudioManager);
+    if (!sStaticAudioManager)
+    {
+        Logging::LogFatal(__FUNCTION__) << "Audio manager singleton not set" << std::endl;
+        throw std::runtime_error("Audio manager singleton not set");
+    }
     return *sStaticAudioManager;
 }
 
@@ -108,25 +97,63 @@ void AudioManager::Set(AudioManager* audioManager)
     sStaticAudioManager = audioManager;
 }
 
+void AudioManager::EnqueueCommand(Command cmd)
+{
+    {
+        std::lock_guard<std::mutex> lock(mCommandMutex);
+        mCommandQueue.emplace_back(std::move(cmd));
+    }
+    mCommandCv.notify_one();
+}
+
+void AudioManager::AudioLoop()
+{
+    while (true)
+    {
+        Command cmd;
+        {
+            std::unique_lock<std::mutex> lock(mCommandMutex);
+            mCommandCv.wait(lock, [this]{ return !mCommandQueue.empty(); });
+            cmd = std::move(mCommandQueue.front());
+            mCommandQueue.pop_front();
+        }
+
+        if (std::holds_alternative<CommandShutdown>(cmd))
+        {
+            DoShutdown();
+            return;
+        }
+
+        std::visit(overloaded{
+            [this](CommandPlaySound c){ DoPlaySound(c.sound); },
+            [this](CommandChangeTrack c){ DoChangeTrack(c.music); },
+            [this](CommandPopTrack){ DoPopTrack(); },
+            [this](CommandStopTrack){ DoStopTrack(); },
+            [this](CommandSwitchPlayer c){ DoSwitchPlayer(c.player); },
+            [this](CommandSoundFinished c){ DoSoundFinished(c.music); },
+            [](CommandShutdown){}},
+            cmd);
+    }
+}
+
+void AudioManager::DoShutdown()
+{
+    ClearSounds();
+    Mix_CloseAudio();
+}
+
 void AudioManager::ChangeMusicTrack(MusicIndex musicI)
 {
-    if (!mMusicStack.empty())
-    {
-        mMusicStack.pop();
-    }
-
-    auto* music = GetMusic(musicI);
-    mMusicStack.push(music);
-    mLogger.Debug() << "Changing track to: " << musicI
-        << " stack size: " << mMusicStack.size() << "\n";
-
-    PlayTrack(music);
+    mLogger.Debug() << "Changing track to: " << musicI << "\n";
+    EnqueueCommand(CommandChangeTrack{musicI});
 }
 
 void AudioManager::PlayTrack(Mix_Music* music)
 {
     if (music == mCurrentMusicTrack)
+    {
         return;
+    }
 
     const auto startTime = Mix_GetMusicLoopStartTime(music);
 
@@ -142,7 +169,27 @@ void AudioManager::PlayTrack(Mix_Music* music)
     mCurrentMusicTrack = music;
 }
 
+void AudioManager::DoChangeTrack(MusicIndex musicI)
+{
+    if (!mMusicStack.empty())
+    {
+        mMusicStack.pop();
+    }
+
+    auto* music = GetMusic(musicI);
+    mMusicStack.push(music);
+    mLogger.Debug() << "Changing track to: " << musicI
+        << " stack size: " << mMusicStack.size() << "\n";
+
+    PlayTrack(music);
+}
+
 void AudioManager::PopTrack()
+{
+    EnqueueCommand(CommandPopTrack{});
+}
+
+void AudioManager::DoPopTrack()
 {
     if (mMusicStack.empty())
     {
@@ -168,20 +215,32 @@ void AudioManager::PopTrack()
 
 void AudioManager::PlaySound(SoundIndex sound)
 {
-    std::lock_guard<std::mutex> lock(mQueueMutex);
     mLogger.Debug() << "Queueing sound: " << sound << "\n";
-    mSoundQueue.emplace(sound);
+    EnqueueCommand(CommandPlaySound{sound});
+}
+
+void AudioManager::DoPlaySound(SoundIndex sound)
+{
+    if (mSoundPlaying)
+    {
+        mPendingSounds.emplace(sound);
+    }
+    else
+    {
+        PlaySoundImpl(sound);
+    }
 }
 
 void AudioManager::PlaySoundImpl(SoundIndex sound)
 {
     mLogger.Debug()  << "Playing sound: " << sound << "\n";
 
-    mSoundPlaying = true;
     std::visit(overloaded{
-        [](Mix_Music* music){
+        [this](Mix_Music* music){
+            mCurrentSound = music;
+            mSoundPlaying = true;
+            Mix_HookMusicStreamFinished(music, &AudioManager::SoundFinishedHook, this);
             Mix_PlayMusicStream(music, 1);
-            Mix_HookMusicStreamFinished(music, &AudioManager::RewindMusic, nullptr);
         },
         [](Mix_Chunk* chunk){
             
@@ -189,33 +248,114 @@ void AudioManager::PlaySoundImpl(SoundIndex sound)
         GetSound(sound));
 }
 
-void AudioManager::RewindMusic(Mix_Music* music, void*)
+void AudioManager::SoundFinishedHook(Mix_Music* music, void* self)
 {
-    // This seems to be necessary for some midi snippets that e.g. 61 DRAG
-    // that stop playing back after they've been played once or twice...
-    //Mix_RewindMusicStream(music);
-    Mix_FreeMusic(music);
-    auto& soundData = Get().mSoundData;
-    soundData.erase(
-        std::find_if(
-            soundData.begin(),
-            soundData.end(),
-            [music](const auto& sound)
-            {
-                return std::holds_alternative<Mix_Music*>(sound.second) 
-                    && std::get<Mix_Music*>(sound.second) == music;
-            }));
-
-    Get().mSoundPlaying = false;
+    auto* audioManager = static_cast<AudioManager*>(self);
+    audioManager->EnqueueCommand(CommandSoundFinished{music});
 }
 
-void AudioManager::StopMusicTrack()
+void AudioManager::DoSoundFinished(Mix_Music* music)
+{
+    if (music != mCurrentSound)
+        return;
+
+    mSoundPlaying = false;
+    mCurrentSound = nullptr;
+
+    auto it = std::find_if(
+        mSoundData.begin(),
+        mSoundData.end(),
+        [music](const auto& sound)
+        {
+            return std::holds_alternative<Mix_Music*>(sound.second) 
+                && std::get<Mix_Music*>(sound.second) == music;
+        });
+
+    if (it != mSoundData.end())
+    {
+        Mix_FreeMusic(music);
+        mSoundData.erase(it);
+    }
+
+    if (!mPendingSounds.empty())
+    {
+        auto sound = mPendingSounds.front();
+        mPendingSounds.pop();
+        PlaySoundImpl(sound);
+    }
+}
+
+void AudioManager::DoStopTrack()
 {
     if (mCurrentMusicTrack)
     {
         Mix_FadeOutMusicStream(mCurrentMusicTrack, 2000);
         mCurrentMusicTrack = nullptr;
     }
+}
+
+void AudioManager::DoSwitchPlayer(MidiPlayer midiPlayer)
+{
+    ClearSounds();
+
+    switch (midiPlayer)
+    {
+    case MidiPlayer::ADLMIDI:
+        Mix_SetMidiPlayer(MIDI_ADLMIDI);
+        break;
+    case MidiPlayer::OPNMIDI:
+        Mix_SetMidiPlayer(MIDI_OPNMIDI);
+        break;
+    case MidiPlayer::FluidSynth:
+        Mix_SetMidiPlayer(MIDI_Fluidsynth);
+        break;
+    default:
+        std::unreachable();
+    }
+}
+
+void AudioManager::ClearSounds()
+{
+    mCurrentMusicTrack = nullptr;
+    mPendingSounds = {};
+
+    for (auto& [_, music] : mMusicData)
+    {
+        Mix_HaltMusicStream(music);
+        Mix_FreeMusic(music);
+    }
+    mMusicData.clear();
+
+    for (auto& [_, sound] : mSoundData)
+    {
+        std::visit(overloaded{
+            [](Mix_Music* music){
+                Mix_HaltMusicStream(music);
+                Mix_FreeMusic(music);
+            },
+            [](Mix_Chunk* chunk){
+                Mix_FreeChunk(chunk);
+            }},
+            sound);
+    }
+    mSoundData.clear();
+
+    while (!mMusicStack.empty()) mMusicStack.pop();
+
+    mSoundPlaying = false;
+    mCurrentSound = nullptr;
+
+    {
+        std::lock_guard<std::mutex> lock(mCommandMutex);
+        std::erase_if(mCommandQueue, [](const Command& c){
+            return std::holds_alternative<CommandSoundFinished>(c);
+        });
+    }
+}
+
+void AudioManager::StopMusicTrack()
+{
+    EnqueueCommand(CommandStopTrack{});
 }
 
 Mix_Music* AudioManager::GetMusic(MusicIndex music)
@@ -271,61 +411,13 @@ AudioManager::Sound AudioManager::GetSound(SoundIndex sound)
 
 void AudioManager::SwitchMidiPlayer(MidiPlayer midiPlayer)
 {
-    ClearSounds();
-
-    switch (midiPlayer)
-    {
-    case MidiPlayer::ADLMIDI:
-        Mix_SetMidiPlayer(MIDI_ADLMIDI);
-        break;
-    case MidiPlayer::OPNMIDI:
-        Mix_SetMidiPlayer(MIDI_OPNMIDI);
-        break;
-    case MidiPlayer::FluidSynth:
-        Mix_SetMidiPlayer(MIDI_Fluidsynth);
-        break;
-    default:
-        throw std::runtime_error("Invalid midi player type");
-    }
-}
-
-void AudioManager::ClearSounds()
-{
-    std::lock_guard<std::mutex> lock(mQueueMutex);
-    mCurrentMusicTrack = nullptr;
-
-    for (auto& [_, music] : mMusicData)
-    {
-        Mix_HaltMusicStream(music);
-        Mix_FreeMusic(music);
-    }
-    mMusicData.clear();
-
-    for (auto& [_, sound] : mSoundData)
-    {
-        std::visit(overloaded{
-            [](Mix_Music* music){
-                Mix_HaltMusicStream(music);
-                Mix_FreeMusic(music);
-            },
-            [](Mix_Chunk* chunk){
-                Mix_FreeChunk(chunk);
-            }},
-            sound);
-    }
-    mSoundData.clear();
-
-    while (!mMusicStack.empty()) mMusicStack.pop();
-
-    mSoundPlaying = false;
+    EnqueueCommand(CommandSwitchPlayer{midiPlayer});
 }
 
 AudioManager::~AudioManager()
 {
-    mRunning = false;
-    mQueuePlayThread.join();
-    ClearSounds();
-    Mix_CloseAudio();
+    EnqueueCommand(CommandShutdown{});
+    mAudioThread.join();
     SDL_Quit();
 }
 

--- a/audio/audio.hpp
+++ b/audio/audio.hpp
@@ -6,7 +6,8 @@
 #include <SDL2/SDL.h>
 #include "SDL_mixer_ext/SDL_mixer_ext.h"
 
-#include <atomic>
+#include <condition_variable>
+#include <deque>
 #include <queue>
 #include <stack>
 #include <thread>
@@ -79,6 +80,40 @@ private:
 
 IAudioManager& GetAudioManager();
 
+struct CommandPlaySound
+{
+    SoundIndex sound;
+};
+
+struct CommandChangeTrack
+{
+    MusicIndex music;
+};
+
+struct CommandPopTrack {};
+struct CommandStopTrack {};
+
+struct CommandSwitchPlayer
+{
+    MidiPlayer player;
+};
+
+struct CommandSoundFinished
+{
+    Mix_Music* music;
+};
+
+struct CommandShutdown {};
+
+using Command = std::variant<
+    CommandPlaySound,
+    CommandChangeTrack,
+    CommandPopTrack,
+    CommandStopTrack,
+    CommandSwitchPlayer,
+    CommandSoundFinished,
+    CommandShutdown>;
+
 class AudioManager : public IAudioManager
 {
     static constexpr auto sAudioRate{MIX_DEFAULT_FREQUENCY};
@@ -90,7 +125,6 @@ class AudioManager : public IAudioManager
     static constexpr auto sFadeOutTime{1500};
 
     using Sound = std::variant<Mix_Music*, Mix_Chunk*>;
-
 public:
     AudioManager();
 
@@ -109,6 +143,18 @@ public:
 
     ~AudioManager();
 private:
+    void EnqueueCommand(Command cmd);
+
+    void AudioLoop();
+
+    void DoPlaySound(SoundIndex);
+    void DoChangeTrack(MusicIndex);
+    void DoPopTrack();
+    void DoStopTrack();
+    void DoSwitchPlayer(MidiPlayer);
+    void DoSoundFinished(Mix_Music*);
+    void DoShutdown();
+
     void PlayTrack(Mix_Music* music);
     void PlaySoundImpl(SoundIndex);
 
@@ -116,25 +162,27 @@ private:
 
     Mix_Music* GetMusic(MusicIndex);
 
-    static void RewindMusic(Mix_Music*, void*);
+    static void SoundFinishedHook(Mix_Music*, void*);
 
     void ClearSounds();
 
     Mix_Music* mCurrentMusicTrack{nullptr};
     std::stack<Mix_Music*> mMusicStack{};
-    std::queue<SoundIndex> mSoundQueue{};
+    std::queue<SoundIndex> mPendingSounds{};
     bool mSoundPlaying{};
+    Mix_Music* mCurrentSound{nullptr};
 
     std::unordered_map<SoundIndex, Sound> mSoundData{};
     std::unordered_map<MusicIndex, Mix_Music*> mMusicData{};
 
-    std::atomic<bool> mRunning{};
-    std::mutex mQueueMutex{};
-    std::thread mQueuePlayThread;
-    static AudioManager* sStaticAudioManager;
+    std::deque<Command> mCommandQueue{};
+    std::mutex mCommandMutex{};
+    std::condition_variable mCommandCv{};
 
     const Logging::Logger& mLogger;
-    
+    std::thread mAudioThread;
+    static AudioManager* sStaticAudioManager;
+
 };
 
 }


### PR DESCRIPTION
Replace the half-baked sound queue with a proper command queue, all SDL API calls now occur ONLY on the audio thread.