### PR TITLE
Issue #217 - Render 3D view in viewport and use correct perspective

### DIFF
--- a/app/display_object.cpp
+++ b/app/display_object.cpp
@@ -60,6 +60,7 @@ int main(int argc, char** argv)
 
     auto nativeWidth = 320.0f;
     auto nativeHeight = 200.0f;
+    static constexpr auto sFocalLength = 512.0f;
 
     auto width = nativeWidth * guiScalar;
     auto height = nativeHeight * guiScalar;
@@ -74,8 +75,11 @@ int main(int argc, char** argv)
     auto renderer = Graphics::Renderer{
         width,
         height,
+        glm::ivec4{0, 0, static_cast<int>(width), static_cast<int>(height)},
         1024,
         1024};
+    const auto fieldOfView = CalculateFieldOfView(nativeHeight, sFocalLength);
+
     auto renderData = Graphics::RenderData{};
     renderData.LoadData(
         zoneData->mObjects,
@@ -83,15 +87,15 @@ int main(int argc, char** argv)
         zoneData->mZoneTextures.GetMaxDim());
 
     Camera lightCamera{
-        glm::uvec2{static_cast<unsigned>(nativeWidth), static_cast<unsigned>(nativeHeight)},
-        glm::uvec2{static_cast<unsigned>(width), static_cast<unsigned>(height)},
+        glm::vec2{nativeWidth, nativeHeight},
+        fieldOfView,
         400 * 30.0f,
         2.0f};
     lightCamera.UseOrthoMatrix(400, 400);
 
     Camera camera{
-        glm::uvec2{static_cast<unsigned>(nativeWidth), static_cast<unsigned>(nativeHeight)},
-        glm::uvec2{static_cast<unsigned>(width), static_cast<unsigned>(height)},
+        glm::vec2{nativeWidth, nativeHeight},
+        fieldOfView,
         50*30.0f,
         2.0f};
     Camera* cameraPtr = &camera;

--- a/app/main3d.cpp
+++ b/app/main3d.cpp
@@ -241,11 +241,8 @@ int main(int argc, char** argv)
     bool showImgui = config.mGraphics.mEnableImGui;
     auto guiScalar = config.mGraphics.mResolutionScale;
 
-    auto nativeWidth = 320.0f;
-    auto nativeHeight = 200.0f;
-
-    auto width = nativeWidth * guiScalar;
-    auto height = nativeHeight * guiScalar;
+    auto width = BAK::gNativeScreenWidth * guiScalar;
+    auto height = BAK::gNativeScreenHeight * guiScalar;
     auto guiScaleInv = glm::vec2{1 / guiScalar, 1 / guiScalar};
 
     /* OPEN GL / GLFW SETUP  */
@@ -279,21 +276,28 @@ int main(int argc, char** argv)
     root.AddChildFront(&guiManager);
     guiManager.EnterMainMenu(false);
 
+    static constexpr auto sDefaultFocalLength = 512.f;
+    const auto zoneViewport = BAK::LoadZoneViewport();
+    const auto zoneViewportGL = BAK::ToGlViewport(zoneViewport, guiScalar);
+    const auto viewportDimensions = glm::vec2{zoneViewport.mWidth, zoneViewport.mHeight};
+    const auto defaultFieldOfView = CalculateFieldOfView(
+        viewportDimensions.y, sDefaultFocalLength);
+
     Camera lightCamera{
-        glm::uvec2{static_cast<unsigned>(nativeWidth), static_cast<unsigned>(nativeHeight)},
-        glm::uvec2{static_cast<unsigned>(width), static_cast<unsigned>(height)},
+        viewportDimensions,
+        defaultFieldOfView,
         static_cast<float>(config.mGame.mMoveUnitsPerSecond),
         2.0f};
     lightCamera.UseOrthoMatrix(400, 400);
 
     Camera partyCamera{
-        glm::uvec2{static_cast<unsigned>(nativeWidth), static_cast<unsigned>(nativeHeight)},
-        glm::uvec2{static_cast<unsigned>(width), static_cast<unsigned>(height)},
+        viewportDimensions,
+        defaultFieldOfView,
         static_cast<float>(config.mGame.mMoveUnitsPerSecond),
         1.0f};
     Camera viewCamera{
-        glm::uvec2{static_cast<unsigned>(nativeWidth), static_cast<unsigned>(nativeHeight)},
-        glm::uvec2{static_cast<unsigned>(width), static_cast<unsigned>(height)},
+        viewportDimensions,
+        defaultFieldOfView,
         static_cast<float>(config.mGame.mMoveUnitsPerSecond),
         1.0f};
     Camera* cameraPtr = &partyCamera;
@@ -306,6 +310,7 @@ int main(int argc, char** argv)
     auto renderer = Graphics::Renderer{
         width,
         height,
+        zoneViewportGL,
         sShadowDim,
         sShadowDim,
         config.mGraphics.mDrawDistance};
@@ -635,7 +640,7 @@ int main(int argc, char** argv)
                 renderer.EndDepthMapDraw();
             }
 
-            glViewport(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height));
+            glViewport(zoneViewportGL.x, zoneViewportGL.y, zoneViewportGL.z, zoneViewportGL.w);
             // Dark blue background
             if (gameRunner.mGameState.IsUnderground())
             {

--- a/bak/camera.cpp
+++ b/bak/camera.cpp
@@ -8,11 +8,17 @@
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 
+#include <cmath>
 #include <utility>
 
+float CalculateFieldOfView(float viewportHeight, float focalLength)
+{
+    return 2.0f * std::atan((viewportHeight * 0.5f) / focalLength);
+}
+
 Camera::Camera(
-    glm::uvec2 nativeDimensions,
-    glm::uvec2 screenDimensions,
+    glm::vec2 viewportDimensions,
+    float fieldOfView,
     float moveSpeed,
     float turnSpeed)
 :
@@ -22,10 +28,10 @@ Camera::Camera(
     mPosition{0,1.4,0},
     mLastPosition{mPosition},
     mDistanceTravelled{0.0},
-    mProjectionMatrix{CalculatePerspectiveMatrix(screenDimensions.x, screenDimensions.y)},
+    mProjectionMatrix{CalculatePerspectiveMatrix(viewportDimensions, fieldOfView)},
     mAngle{3.14, 0},
-    mNativeDimensions{nativeDimensions},
-    mScreenDimensions{screenDimensions}
+    mViewportDimensions{viewportDimensions},
+    mFieldOfView{fieldOfView}
 {}
 
 glm::mat4 Camera::CalculateOrthoMatrix(unsigned width, unsigned height)
@@ -42,11 +48,11 @@ glm::mat4 Camera::CalculateOrthoMatrix(unsigned width, unsigned height)
     );
 }
 
-glm::mat4 Camera::CalculatePerspectiveMatrix(unsigned width, unsigned height)
+glm::mat4 Camera::CalculatePerspectiveMatrix(glm::vec2 viewportDimensions, float fieldOfView)
 {
     return glm::perspective(
-        glm::radians(22.5f),
-        static_cast<float>(width) / static_cast<float>(height),
+        fieldOfView,
+        viewportDimensions.x / viewportDimensions.y,
         1.0f,
         4000.0f
     );
@@ -57,16 +63,15 @@ void Camera::UseOrthoMatrix(unsigned width, unsigned height)
     mProjectionMatrix = CalculateOrthoMatrix(width, height);
 }
 
-void Camera::UsePerspectiveMatrix(unsigned width, unsigned height)
+void Camera::UsePerspectiveMatrix()
 {
-    mProjectionMatrix = CalculatePerspectiveMatrix(width, height);
+    mProjectionMatrix = CalculatePerspectiveMatrix(mViewportDimensions, mFieldOfView);
 }
 
 void Camera::SetGameLocation(const BAK::GamePositionAndHeading& location)
 {
     auto pos = BAK::ToGlCoord<float>(location.mPosition);
-    //pos.y = mPosition.y; 
-    pos.y = BAK::gBakCameraHeight;
+    pos.y = mPosition.y;
     SetPosition(pos);
     auto angle = mAngle;
     angle.x = BAK::ToGlAngle(location.mHeading).x;
@@ -317,12 +322,12 @@ unsigned Camera::GetAndClearUnitsTravelled()
     return 0;
 }
 
-glm::uvec2 Camera::GetNativeDimensions() const
+glm::vec2 Camera::GetViewportDimensions() const
 {
-    return mNativeDimensions;
+    return mViewportDimensions;
 }
 
-glm::uvec2 Camera::GetScreenDimensions() const
+void Camera::SetFieldOfView(float fieldOfView)
 {
-    return mScreenDimensions;
+    mFieldOfView = fieldOfView;
 }

--- a/bak/camera.hpp
+++ b/bak/camera.hpp
@@ -5,19 +5,21 @@
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 
+float CalculateFieldOfView(float viewportHeight, float focalLength);
+
 class Camera
 {
 public:
     Camera(
-        glm::uvec2 nativeDimensions,
-        glm::uvec2 screenDimensions,
+        glm::vec2 viewportDimensions,
+        float fieldOfView,
         float moveSpeed,
         float turnSpeed);
-    
+
     glm::mat4 CalculateOrthoMatrix(unsigned width, unsigned height);
-    glm::mat4 CalculatePerspectiveMatrix(unsigned width, unsigned height);
+    glm::mat4 CalculatePerspectiveMatrix(glm::vec2 viewportDimensions, float fieldOfView);
     void UseOrthoMatrix(unsigned width, unsigned height);
-    void UsePerspectiveMatrix(unsigned width, unsigned height);
+    void UsePerspectiveMatrix();
 
     void SetGameLocation(const BAK::GamePositionAndHeading& location);
     void SetSpeedScale(float scale);
@@ -68,8 +70,8 @@ public:
     bool CheckAndResetDirty();
     unsigned GetAndClearUnitsTravelled();
 
-    glm::uvec2 GetNativeDimensions() const;
-    glm::uvec2 GetScreenDimensions() const;
+    glm::vec2 GetViewportDimensions() const;
+    void SetFieldOfView(float fieldOfView);
 
 private:
     float mMoveSpeed;
@@ -85,8 +87,8 @@ private:
     glm::mat4 mProjectionMatrix;
     glm::vec2 mAngle;
 
-    glm::uvec2 mNativeDimensions;
-    glm::uvec2 mScreenDimensions;
+    glm::vec2 mViewportDimensions;
+    float mFieldOfView;
 
     bool mDirty{};
 };

--- a/bak/collision.cpp
+++ b/bak/collision.cpp
@@ -150,9 +150,10 @@ std::optional<float> ComputeHeight(
 
 float ComputeWorldHeight(
     float height,
-    float itemScale)
+    float itemScale,
+    float baseHeight)
 {
-    return BAK::gBakCameraHeight + height * itemScale;
+    return baseHeight + height * itemScale;
 }
 
 glm::vec2 WorldToModelClipSpace(

--- a/bak/collision.hpp
+++ b/bak/collision.hpp
@@ -25,7 +25,8 @@ std::optional<float> ComputeHeight(
 
 float ComputeWorldHeight(
     float height,
-    float itemScale);
+    float itemScale,
+    float baseHeight);
 
 glm::vec2 WorldToModelClipSpace(
     glm::vec2 playerPos,

--- a/bak/constants.hpp
+++ b/bak/constants.hpp
@@ -9,6 +9,9 @@ namespace BAK {
 
 static constexpr float gWorldScale = 100.;
 
+static constexpr auto gNativeScreenWidth = 320;
+static constexpr auto gNativeScreenHeight = 200;
+
 static constexpr float gTileSize = 64000.;
 static constexpr auto gCellSize = 1600;
 static constexpr auto gHalfCellSize = gCellSize / 2;

--- a/bak/test/collisionTest.cpp
+++ b/bak/test/collisionTest.cpp
@@ -357,9 +357,11 @@ TEST_F(CollisionTestFixture, ComputeHeightFindsCorrectElement)
 
 TEST_F(CollisionTestFixture, ComputeWorldHeightScale)
 {
-    EXPECT_FLOAT_EQ(ComputeWorldHeight(10.0f, 4.0f), 140.0f);
-    EXPECT_FLOAT_EQ(ComputeWorldHeight(0.0f, 1.0f), 100.0f);
-    EXPECT_FLOAT_EQ(ComputeWorldHeight(-5.0f, 2.0f), 90.0f);
+    EXPECT_FLOAT_EQ(ComputeWorldHeight(10.0f, 4.0f, 100.0f), 140.0f);
+    EXPECT_FLOAT_EQ(ComputeWorldHeight(0.0f, 1.0f, 100.0f), 100.0f);
+    EXPECT_FLOAT_EQ(ComputeWorldHeight(-5.0f, 2.0f, 100.0f), 90.0f);
+    EXPECT_FLOAT_EQ(ComputeWorldHeight(0.0f, 1.0f, 230.0f), 230.0f);
+    EXPECT_FLOAT_EQ(ComputeWorldHeight(10.0f, 3.0f, 250.0f), 280.0f);
 }
 
 }

--- a/bak/zone.cpp
+++ b/bak/zone.cpp
@@ -1,6 +1,8 @@
 #include "bak/zone.hpp"
 
+#include "bak/constants.hpp"
 #include "bak/encounter/encounter.hpp"
+#include "bak/fileBufferFactory.hpp"
 #include "bak/fixedObject.hpp"
 #include "bak/palette.hpp"
 #include "bak/resourceNames.hpp"
@@ -11,6 +13,8 @@
 #include "graphics/quad.hpp"
 
 #include "com/assert.hpp"
+
+#include <cmath>
 
 namespace BAK {
 
@@ -130,6 +134,27 @@ Zone::Zone(unsigned zoneNumber)
         mZoneTextures.AddTexture(gridTex);
         mObjects.AddObject("GridCell", MakeGridQuadMesh(gridLayer));
     }
+}
+
+ZoneViewport LoadZoneViewport()
+{
+    auto fb = FileBufferFactory::Get().CreateDataBuffer("ZONE.DAT");
+    const auto x = fb.GetUint16LE();
+    const auto y = fb.GetUint16LE();
+    const auto width = fb.GetUint16LE();
+    const auto height = fb.GetUint16LE();
+
+    return ZoneViewport{x, y, width, height};
+}
+
+glm::ivec4 ToGlViewport(ZoneViewport viewport, float scale)
+{
+    const auto x = std::round(viewport.mX * scale);
+    const auto y = std::round((gNativeScreenHeight - (viewport.mY + viewport.mHeight)) * scale);
+    const auto width = std::round(viewport.mWidth * scale);
+    const auto height = std::round(viewport.mHeight * scale);
+
+    return glm::ivec4{x, y, width, height};
 }
 
 bool IsUnderground(ZoneNumber zone)

--- a/bak/zone.hpp
+++ b/bak/zone.hpp
@@ -9,9 +9,22 @@
 
 #include "graphics/meshObject.hpp"
 
+#include <glm/glm.hpp>
+
 #include <vector>
 
 namespace BAK {
+
+struct ZoneViewport
+{
+    int mX;
+    int mY;
+    int mWidth;
+    int mHeight;
+};
+
+ZoneViewport LoadZoneViewport();
+glm::ivec4 ToGlViewport(ZoneViewport viewport, float scale);
 
 // Contains all the data one would need for a zone
 class Zone

--- a/bak/zoneDef.cpp
+++ b/bak/zoneDef.cpp
@@ -15,8 +15,8 @@ ZoneDefaults LoadZoneDefDat(ZoneNumber zone)
     Logging::LogDebug(__FUNCTION__) << "Zone: " << zone.mValue << "\n";
 
     const auto zoneType = fb.GetUint16LE();
-    const auto threeDParam = fb.GetUint16LE();
-    const auto playerPos_fieldA = fb.GetUint32LE();
+    const auto focalLengthScale = fb.GetUint16LE();
+    const auto defaultCameraHeight = fb.GetUint32LE();
     const auto playerPos_fieldE = fb.GetUint16LE();
     const auto horizonDisplayType = fb.GetUint16LE();
     const auto groundType = fb.GetUint8();
@@ -33,8 +33,9 @@ ZoneDefaults LoadZoneDefDat(ZoneNumber zone)
     const auto unknown16 = fb.GetUint32LE();
     const auto unknown17 = fb.GetUint32LE();
 
-    Logging::LogDebug(__FUNCTION__) << "ZoneType: " << zoneType << " 3dParam? " << threeDParam <<"\n";
-    Logging::LogDebug(__FUNCTION__) << "PlayerPos A: " << playerPos_fieldA << " PlayerPos E: " << playerPos_fieldE << "\n";
+    Logging::LogDebug(__FUNCTION__) << "ZoneType: " << zoneType << " focalLengthScale " << focalLengthScale <<"\n";
+    Logging::LogDebug(__FUNCTION__) << "DefaultCameraHeight: " << defaultCameraHeight
+        << " PlayerPos E: " << playerPos_fieldE << "\n";
     Logging::LogDebug(__FUNCTION__) << "HorizonAndGroundType: " << horizonDisplayType << "\n";
     Logging::LogDebug(__FUNCTION__) << "GroundType: " << +groundType << " GroundHeight: " << +groundHeight << "\n";
     Logging::LogDebug(__FUNCTION__) << " minMapZoom: " << minMapZoom << " defaultMapZoom: " << defaultMapZoom << "\n";
@@ -50,7 +51,9 @@ ZoneDefaults LoadZoneDefDat(ZoneNumber zone)
         static_cast<float>(minMapZoom),
         static_cast<float>(defaultMapZoom),
         static_cast<float>(maxMapZoom),
-        static_cast<float>(mapZoomRate)};
+        static_cast<float>(mapZoomRate),
+        static_cast<int>(defaultCameraHeight),
+        focalLengthScale};
 }
 
 };

--- a/bak/zoneDef.hpp
+++ b/bak/zoneDef.hpp
@@ -10,6 +10,8 @@ struct ZoneDefaults
     float mDefaultMapZoom;
     float mMaxMapZoom;
     float mMapZoomRate;
+    int mDefaultCameraHeight;
+    int mFocalLengthScale;
 };
 
 ZoneDefaults LoadZoneDefDat(ZoneNumber zone);

--- a/game/gameRunner.cpp
+++ b/game/gameRunner.cpp
@@ -179,11 +179,7 @@ void GameRunner::ShowFirstPersonView()
     mGameState.SetOverheadView(false);
     ToggleUndergroundModels();
 
-    auto dims = mViewCamera.GetNativeDimensions();
-    mViewCamera.UsePerspectiveMatrix(
-        static_cast<unsigned>(dims.x),
-        static_cast<unsigned>(dims.y)
-    );
+    mViewCamera.UsePerspectiveMatrix();
 
     RestoreFirstPersonVisibility();
     ShowOverheadHidden();
@@ -224,8 +220,8 @@ void GameRunner::ZoomIn()
 glm::uvec2 GameRunner::GetOrthoViewDimensions() const
 {
     const auto orthoViewSize = BAK::gTileSize / BAK::gWorldScale;
-    const auto nativeDims = glm::vec2(mViewCamera.GetNativeDimensions());
-    const auto aspectRatio = nativeDims.x / nativeDims.y;
+    const auto viewportDimensions = mViewCamera.GetViewportDimensions();
+    const auto aspectRatio = viewportDimensions.x / viewportDimensions.y;
     return glm::uvec2(orthoViewSize * aspectRatio, orthoViewSize);
 }
 
@@ -249,10 +245,25 @@ void GameRunner::LoadZoneData(BAK::ZoneNumber zone)
         mZoneData->mZoneTextures.GetTextures(),
         mZoneData->mZoneTextures.GetMaxDim());
     LoadSystems();
+
+    mZoomManager.LoadZoneDefaults(zone);
+    mMovementManager.SetDefaultHeight(
+        static_cast<float>(mZoomManager.GetDefaultCameraHeight()));
+
     mPartyCamera.SetGameLocation(mGameState.GetLocation());
     mCurrentTile = mPartyCamera.GetGameTile();
     mMovementManager.RefreshAfterZoneLoad();
-    mZoomManager.LoadZoneDefaults(zone);
+
+    const auto focalLength = static_cast<float>(1 << mZoomManager.GetFocalLengthScale());
+    const auto fieldOfView = CalculateFieldOfView(
+        mPartyCamera.GetViewportDimensions().y, focalLength);
+    mPartyCamera.SetFieldOfView(fieldOfView);
+    mViewCamera.SetFieldOfView(fieldOfView);
+    if (!mGameState.GetOverheadView())
+    {
+        mPartyCamera.UsePerspectiveMatrix();
+        mViewCamera.UsePerspectiveMatrix();
+    }
 }
 
 void GameRunner::DoTransition(
@@ -855,7 +866,7 @@ void GameRunner::CombatCompleted(BAK::CombatResult result)
             combat, mRetreatDirection);
 
         mSavedCameraPos = BAK::ToGlCoord<float>(retreatPos.mPosition);
-        mSavedCameraPos.y = BAK::gBakCameraHeight;
+        mSavedCameraPos.y = mMovementManager.GetDefaultHeight();
         mSavedCameraAngle = BAK::ToGlAngle(retreatPos.mHeading);
 
         mGameState.SetLocation(
@@ -1333,7 +1344,7 @@ const Graphics::RenderData& GameRunner::GetMapIconsRenderData() const
 void GameRunner::UpdatePartyMarkerScale(glm::uvec2 orthoDims)
 {
     const auto unitsPerPixel = static_cast<float>(orthoDims.x)
-        / static_cast<float>(mViewCamera.GetNativeDimensions().x);
+        / mViewCamera.GetViewportDimensions().x;
     const auto dims = mMapIcons.GetDimensions();
     const auto w = static_cast<float>(dims.x);
     const auto h = static_cast<float>(dims.y);

--- a/game/movementManager.cpp
+++ b/game/movementManager.cpp
@@ -297,10 +297,8 @@ void MovementManager::SetFollowRoadButtonVisible(bool visible)
 
 void MovementManager::UpdateTerrainHeight()
 {
-    if (auto height = ComputeTerrainHeight(mCamera.GetGameLocation().mPosition))
-    {
-        mCamera.SetHeight(*height);
-    }
+    mCamera.SetHeight(
+        ComputeTerrainHeight(mCamera.GetGameLocation().mPosition));
 }
 
 void MovementManager::RefreshAfterZoneLoad()
@@ -328,11 +326,11 @@ void MovementManager::ToggleFollowRoad()
     }
 }
 
-std::optional<float> MovementManager::ComputeTerrainHeight(BAK::GamePosition playerPos) const
+float MovementManager::ComputeTerrainHeight(BAK::GamePosition playerPos) const
 {
     if (!mSystems)
     {
-        return std::nullopt;
+        return mDefaultHeight;
     }
 
     const auto playerBakPos = glm::ivec2{playerPos};
@@ -349,11 +347,14 @@ std::optional<float> MovementManager::ComputeTerrainHeight(BAK::GamePosition pla
         auto height = BAK::ComputeHeight(modelSpace, item.GetModelClip());
         if (height)
         {
-            return BAK::ComputeWorldHeight(*height, item.GetScale());
+            return BAK::ComputeWorldHeight(
+                *height,
+                item.GetScale(),
+                mDefaultHeight);
         }
     }
 
-    return std::nullopt;
+    return mDefaultHeight;
 }
 
 std::optional<BAK::GameHeading> MovementManager::GetOpenDirection(
@@ -621,6 +622,16 @@ void MovementManager::MoveRight()
         return;
     }
     mCamera.StrafeRight();
+}
+
+void MovementManager::SetDefaultHeight(float height)
+{
+    mDefaultHeight = height;
+}
+
+float MovementManager::GetDefaultHeight() const
+{
+    return mDefaultHeight;
 }
 
 void MovementManager::MoveForward(bool strafe)

--- a/game/movementManager.hpp
+++ b/game/movementManager.hpp
@@ -46,6 +46,9 @@ public:
     void SetSystems(Systems* systems);
     void SetDoorLocations(const DoorLocationMap* doorLocations);
 
+    void SetDefaultHeight(float height);
+    float GetDefaultHeight() const;
+
     void MoveForward(bool strafe);
     void MoveBackward(bool strafe);
     void MoveLeft();
@@ -59,7 +62,7 @@ public:
     bool IsOnPit(glm::uvec2 pos) const;
     std::optional<PitCross> GetPitCross(
         BAK::GamePosition playerPos, glm::uvec2 pitLocation) const;
-    std::optional<float> ComputeTerrainHeight(BAK::GamePosition playerPos) const;
+    float ComputeTerrainHeight(BAK::GamePosition playerPos) const;
     std::optional<BAK::GameHeading> GetOpenDirection(
         BAK::GamePositionAndHeading playerLocation, float distance, bool followRoad) const;
 
@@ -90,6 +93,7 @@ private:
     Gui::GuiManager& mGuiManager;
     Systems* mSystems{nullptr};
     const DoorLocationMap* mDoorLocations{nullptr};
+    float mDefaultHeight{BAK::gBakCameraHeight};
     bool mClipEnabled{false};
     bool mWallSlide{false};
 

--- a/game/zoomManager.cpp
+++ b/game/zoomManager.cpp
@@ -55,6 +55,16 @@ glm::uvec2 ZoomManager::CalculateZoom(glm::vec2 screenDims)
         << " zoomed: " << zoomed << "\n";
     return zoomed;
 }
+    
+int ZoomManager::GetFocalLengthScale() const
+{
+    return mZoneDefaults.mFocalLengthScale;
+}
+
+int ZoomManager::GetDefaultCameraHeight() const
+{
+    return mZoneDefaults.mDefaultCameraHeight;
+}
 
 bool ZoomManager::CanZoomIn() const
 {

--- a/game/zoomManager.hpp
+++ b/game/zoomManager.hpp
@@ -17,6 +17,9 @@ public:
     glm::uvec2 DefaultZoom(glm::uvec2 screenDims);
     glm::uvec2 CalculateZoom(glm::vec2 screenDims);
 
+    int GetFocalLengthScale() const;
+    int GetDefaultCameraHeight() const;
+
     bool CanZoomIn() const;
     bool CanZoomOut() const;
 

--- a/graphics/guiRenderer.cpp
+++ b/graphics/guiRenderer.cpp
@@ -104,6 +104,7 @@ GuiRenderer::GuiRenderer(
 void GuiRenderer::RenderGui(
     Graphics::IGuiElement* element)
 {
+    glViewport(0, 0, static_cast<GLsizei>(mDimensions.x), static_cast<GLsizei>(mDimensions.y));
     glDisable(GL_DEPTH_TEST);
     mShader.UseProgramGL();
 

--- a/graphics/renderer.hpp
+++ b/graphics/renderer.hpp
@@ -84,6 +84,7 @@ public:
     Renderer(
         float screenWidth,
         float screenHeight,
+        glm::ivec4 zoneViewport,
         unsigned depthMapWidth,
         unsigned depthMapHeight,
         int drawDistance = 128000)
@@ -201,7 +202,8 @@ public:
         mDepthMapDims{depthMapWidth, depthMapHeight},
         mDepthFB{},
         mDepthBuffer{GL_TEXTURE_2D},
-        mScreenDims{screenWidth, screenHeight}
+        mScreenDims{screenWidth, screenHeight},
+        mZoneViewport{zoneViewport}
     {
         mPickTexture.MakePickBuffer(screenWidth, screenHeight);
         mPickDepth.MakeDepthBuffer(screenWidth, screenHeight);
@@ -211,7 +213,7 @@ public:
         mHoverPBO.Allocate<glm::vec4>(GL_DYNAMIC_READ);
 
         mDepthBuffer.MakeDepthBuffer(
-            mDepthMapDims.x, 
+            mDepthMapDims.x,
             mDepthMapDims.y);
         mDepthFB.AttachDepthTexture(mDepthBuffer, true);
     }
@@ -227,7 +229,7 @@ public:
         renderData.Bind(GL_TEXTURE0);
 
         mPickFB.BindGL();
-        glViewport(0, 0, mScreenDims.x, mScreenDims.y);
+        glViewport(mZoneViewport.x, mZoneViewport.y, mZoneViewport.z, mZoneViewport.w);
 
         glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -542,6 +544,7 @@ private:
     FrameBuffer mDepthFB;
     TextureBuffer mDepthBuffer;
     glm::vec2 mScreenDims;
+    glm::ivec4 mZoneViewport;
 };
 
 }

--- a/gui/backgrounds.cpp
+++ b/gui/backgrounds.cpp
@@ -1,6 +1,8 @@
 #include "gui/backgrounds.hpp"
 
+#include "bak/constants.hpp"
 #include "bak/textureFactory.hpp"
+#include "bak/zone.hpp"
 
 #include "com/logger.hpp"
 
@@ -80,22 +82,27 @@ Backgrounds::Backgrounds(
                 pixel = Color::black;
             }
         }
-        for (unsigned x = 13; x < (294 + 13); x++)
+        const auto vp = BAK::LoadZoneViewport();
+        for (int x = vp.mX; x < (vp.mWidth + vp.mX); x++)
         {
-            for (unsigned y = (200 - 13); y > (200 - (100 + 13)); y--)
+            for (int y = (BAK::gNativeScreenHeight - vp.mY);
+                y > (BAK::gNativeScreenHeight - (vp.mHeight + vp.mY));
+                y--)
             {
                 tex.SetPixel(x, y, glm::vec4{0});
             }
         }
-        for (unsigned x = 13; x < (294 + 13); x++)
+        for (int x = vp.mX; x < (vp.mWidth + vp.mX); x++)
         {
-            tex.SetPixel(x, (200 - (100 + 13)), Color::frameMaroon);
-            tex.SetPixel(x, (200 - 13), Color::frameMaroon);
+            tex.SetPixel(x, (BAK::gNativeScreenHeight - (vp.mHeight + vp.mY)), Color::frameMaroon);
+            tex.SetPixel(x, (BAK::gNativeScreenHeight - vp.mY), Color::frameMaroon);
         }
-            for (unsigned y = (200 - 13); y > (200 - (100 + 14)); y--)
+        for (int y = (BAK::gNativeScreenHeight - vp.mY);
+            y > (BAK::gNativeScreenHeight - (vp.mHeight + vp.mY + 1));
+            y--)
         {
-            tex.SetPixel(12, y, Color::frameMaroon);
-            tex.SetPixel(294 + 13, y, Color::frameMaroon);
+            tex.SetPixel(vp.mX - 1, y, Color::frameMaroon);
+            tex.SetPixel(vp.mWidth + vp.mX, y, Color::frameMaroon);
         }
     }
 


### PR DESCRIPTION
Avoid rendering the 3D scene and then covering most of it with the GUI.

Use the correct perspective as per BAK specified in Z00DEF.DAT files.

Underground zones in particular use a wider field of view as per the original, makes seeing pits much easier.