### PR TITLE
Issue #78 - Rename ADS/TTM related terminology

### DIFF
--- a/app/display_gds.cpp
+++ b/app/display_gds.cpp
@@ -10,7 +10,7 @@ int main(int argc, char** argv)
     const auto& logger = Logging::LogState::GetLogger("main");
     Logging::LogState::SetLevel(Logging::LogLevel::Spam);
     Logging::LogState::Disable("DialogStore");
-    Logging::LogState::Disable("LoadScenes");
+    Logging::LogState::Disable("LoadScripts");
     Logging::LogState::Disable("LoadSceneIndices");
     Logging::LogState::Disable("FileDataProvider");
     Logging::LogState::Disable("PackedFileDataProvider");

--- a/app/display_ttm.cpp
+++ b/app/display_ttm.cpp
@@ -36,10 +36,10 @@ int main(int argc, char** argv)
             for (const auto& sequence : sequences)
             {
                 std::cout << index << " " << sequence.mName << " [";
-                for (const auto& scene : sequence.mScenes)
+                for (const auto& scene : sequence.mScripts)
                 {
-                    std::cout << " (" << scene.mInitScene
-                        << "," << scene.mDrawScene << ")";
+                    std::cout << " (" << scene.mTTMSlot
+                        << "," << scene.mScriptTag << ")";
                 }
                 std::cout << " ]\n";
             }
@@ -47,14 +47,14 @@ int main(int argc, char** argv)
     }
     else if (mode == "ttm")
     {
-        for (const auto& [index, scene] : BAK::LoadScenes(fb))
+        for (const auto& [index, scene] : BAK::LoadScripts(fb))
         {
             std::cout << index << " " << scene << "\n";
         }
     }
     else if (mode == "dynamic")
     {
-        for (const auto& action : BAK::LoadDynamicScenes(fb))
+        for (const auto& action : BAK::LoadDynamicScripts(fb))
         {
             std::cout << action << "\n";
         }

--- a/app/play_book.cpp
+++ b/app/play_book.cpp
@@ -36,7 +36,7 @@ int main(int argc, char** argv)
     const auto& logger = Logging::LogState::GetLogger("main");
     Logging::LogState::SetLevel(Logging::LogLevel::Debug);
 
-    Logging::LogState::Disable("LoadScenes");
+    Logging::LogState::Disable("LoadScripts");
     Logging::LogState::Disable("LoadSceneIndices");
     Logging::LogState::Disable("DialogStore");
     Logging::LogState::Disable("Gui::Actors");

--- a/app/play_cutscene.cpp
+++ b/app/play_cutscene.cpp
@@ -35,7 +35,7 @@ int main(int argc, char** argv)
     const auto& logger = Logging::LogState::GetLogger("main");
     Logging::LogState::SetLevel(Logging::LogLevel::Debug);
 
-    Logging::LogState::Disable("LoadScenes");
+    Logging::LogState::Disable("LoadScripts");
     Logging::LogState::Disable("LoadSceneIndices");
     Logging::LogState::Disable("DialogStore");
     Logging::LogState::Disable("Gui::Actors");

--- a/app/play_ttm.cpp
+++ b/app/play_ttm.cpp
@@ -28,7 +28,7 @@ int main(int argc, char** argv)
     const auto& logger = Logging::LogState::GetLogger("main");
     Logging::LogState::SetLevel(Logging::LogLevel::Debug);
 
-    Logging::LogState::Disable("LoadScenes");
+    Logging::LogState::Disable("LoadScripts");
     Logging::LogState::Disable("LoadSceneIndices");
     Logging::LogState::Disable("DialogStore");
     Logging::LogState::Disable("Gui::Actors");

--- a/app/show_scene.cpp
+++ b/app/show_scene.cpp
@@ -48,7 +48,7 @@ int main(int argc, char** argv)
     const auto& logger = Logging::LogState::GetLogger("main");
     Logging::LogState::SetLevel(Logging::LogLevel::Debug);
 
-    Logging::LogState::Disable("LoadScenes");
+    Logging::LogState::Disable("LoadScripts");
     Logging::LogState::Disable("LoadSceneIndices");
     Logging::LogState::Disable("DialogStore");
     Logging::LogState::Disable("Gui::Actors");

--- a/bak/hotspot.cpp
+++ b/bak/hotspot.cpp
@@ -232,15 +232,15 @@ SceneHotspots::SceneHotspots(FileBuffer&& fb)
     auto fb2 = FileBufferFactory::Get().CreateDataBuffer(mSceneADS);
     mAdsIndices = BAK::LoadSceneIndices(fb2);
     auto fb3 = FileBufferFactory::Get().CreateDataBuffer(mSceneTTM);
-    mScenes = BAK::LoadScenes(fb3);
+    mScripts = BAK::LoadScripts(fb3);
 }
 
-const Scene& SceneHotspots::GetScene(
+const Script& SceneHotspots::GetScript(
     unsigned adsIndex,
     const GameState& gs)
 {
     const auto ttmIndex = mAdsIndices[adsIndex];
-    return mScenes[ttmIndex.mSceneIndex.GetTTMIndex(gs.GetChapter())];
+    return mScripts[ttmIndex.mSceneIndex.GetTTMIndex(gs.GetChapter())];
 }
 
 std::optional<unsigned> SceneHotspots::GetTempleNumber() const

--- a/bak/hotspot.hpp
+++ b/bak/hotspot.hpp
@@ -105,9 +105,9 @@ public:
 
     std::vector<Hotspot> mHotspots{};
     std::unordered_map<unsigned, SceneIndex> mAdsIndices{};
-    std::unordered_map<unsigned, Scene> mScenes{};
+    std::unordered_map<unsigned, Script> mScripts{};
 
-    const Scene& GetScene(unsigned adsIndex, const GameState& gs);
+    const Script& GetScript(unsigned adsIndex, const GameState& gs);
     std::optional<unsigned> GetTempleNumber() const;
 };
 

--- a/bak/scene/scene.cpp
+++ b/bak/scene/scene.cpp
@@ -68,21 +68,21 @@ std::ostream& operator<<(std::ostream& os, const SceneIndex& si)
     return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const Scene& scene)
+std::ostream& operator<<(std::ostream& os, const Script& scene)
 {
-    os << "Scene :: " << scene.mSceneTag << " [\n";
+    os << "Script :: " << scene.mSceneTag << " [\n";
     for (const auto& a : scene.mActions)
     {
         os << '\t' << a << "\n";
     }
     os << " ]\n";
-    os << "Scene Images: \n";
+    os << "Script Images: \n";
     for (const auto& [key, imagePal] : scene.mImages)
     {
         const auto& [image, palKey] = imagePal;
         os << "K: " << key << " " << image << " pal: " << palKey << "\n";
     }
-    os << "Scene Palettes: \n";
+    os << "Script Palettes: \n";
     for (const auto& [key, pal] : scene.mPalettes)
     {
         os << "K: " << key << " " << pal << "\n";
@@ -132,23 +132,23 @@ std::unordered_map<unsigned, SceneIndex> LoadSceneIndices(FileBuffer& fb)
         
         switch (action)
         {
-            case AdsActions::INDEX:
+            case AdsActions::IF_NOT_PLAYED:
             {
                 const auto a = decompBuffer.GetUint16LE();
                 const auto b = decompBuffer.GetUint16LE();
                 ss << a << " " << b;
             }
                 break;
-            case AdsActions::IF_NOT_PLAYED: [[fallthrough]];
-            case AdsActions::IF_PLAYED: 
+            case AdsActions::IF_NOT_PLAYED_ELSE: [[fallthrough]];
+            case AdsActions::IF_PLAYED_ELSE:
             {
                 const auto a = decompBuffer.GetUint16LE();
                 const auto b = decompBuffer.GetUint16LE();
                 ss << a << " " << b;
             }
                 break;
-            case AdsActions::ADD_SCENE2: [[fallthrough]];
-            case AdsActions::ADD_SCENE:
+            case AdsActions::RESTART_SCRIPT: [[fallthrough]];
+            case AdsActions::START_SCRIPT:
             {
                 const auto a = decompBuffer.GetUint16LE();
                 const auto b = decompBuffer.GetUint16LE();
@@ -184,7 +184,7 @@ std::unordered_map<unsigned, SceneIndex> LoadSceneIndices(FileBuffer& fb)
                 inElseClause = false;
             }
                 break;
-            case AdsActions::STOP_SCENE:
+            case AdsActions::STOP_SCRIPT:
             {
                 const auto a = decompBuffer.GetUint16LE();
                 const auto b = decompBuffer.GetUint16LE();
@@ -213,10 +213,14 @@ std::unordered_map<unsigned, SceneIndex> LoadSceneIndices(FileBuffer& fb)
             // so and and or are not implemented...
             case AdsActions::AND: [[fallthrough]];
             case AdsActions::OR: [[fallthrough]];
-            case AdsActions::FADE_OUT: [[fallthrough]];
-            case AdsActions::END_IF: [[fallthrough]];
-            case AdsActions::PLAY_SCENE: [[fallthrough]];
-            case AdsActions::PLAY_ALL_SCENES:
+            case AdsActions::END_IF_ELSE: [[fallthrough]];
+            case AdsActions::END_IF:
+                break;
+            case AdsActions::STOP_SCENE:
+            {
+                const auto a = decompBuffer.GetUint16LE();
+                ss << a;
+            }
                 break;
         }
 
@@ -268,23 +272,23 @@ std::unordered_map<unsigned, std::vector<SceneSequence>> LoadSceneSequences(File
         
         switch (action)
         {
-            case AdsActions::INDEX:
+            case AdsActions::IF_NOT_PLAYED:
             {
                 const auto a = decompBuffer.GetUint16LE();
                 const auto b = decompBuffer.GetUint16LE();
                 ss << a << " " << b;
             }
                 break;
-            case AdsActions::IF_NOT_PLAYED: [[fallthrough]];
-            case AdsActions::IF_PLAYED: 
+            case AdsActions::IF_NOT_PLAYED_ELSE: [[fallthrough]];
+            case AdsActions::IF_PLAYED_ELSE: 
             {
                 const auto a = decompBuffer.GetUint16LE();
                 const auto b = decompBuffer.GetUint16LE();
                 ss << a << " " << b;
             }
                 break;
-            case AdsActions::ADD_SCENE2: [[fallthrough]];
-            case AdsActions::ADD_SCENE:
+            case AdsActions::RESTART_SCRIPT: [[fallthrough]];
+            case AdsActions::START_SCRIPT:
             {
                 const auto a = decompBuffer.GetUint16LE();
                 const auto b = decompBuffer.GetUint16LE();
@@ -292,10 +296,10 @@ std::unordered_map<unsigned, std::vector<SceneSequence>> LoadSceneSequences(File
                 const auto d = decompBuffer.GetUint16LE();
                 ss << a << " " << b << " " << c << " " << d;
                 ASSERT(currentIndex);
-                currentSequence.mScenes.emplace_back(SceneADS(a, b, false));
+                currentSequence.mScripts.emplace_back(SceneADS(a, b));
             }
                 break;
-            case AdsActions::PLAY_SCENE:
+            case AdsActions::END_IF_ELSE:
             {
                 ASSERT(currentIndex);
                 const auto sceneName = tags.GetTag(Tag{*currentIndex});
@@ -307,7 +311,7 @@ std::unordered_map<unsigned, std::vector<SceneSequence>> LoadSceneSequences(File
                 sceneIndices.at(*currentIndex).emplace_back(currentSequence);
                 currentSequence = {};
             } break;
-            case AdsActions::PLAY_ALL_SCENES:
+            case AdsActions::END_IF:
             {
                 ASSERT(currentIndex);
                 const auto sceneName = tags.GetTag(Tag{*currentIndex});
@@ -321,31 +325,29 @@ std::unordered_map<unsigned, std::vector<SceneSequence>> LoadSceneSequences(File
             {
                 currentIndex.reset();
             } break;
-            case AdsActions::STOP_SCENE:
+            case AdsActions::STOP_SCRIPT:
             {
                 const auto a = decompBuffer.GetUint16LE();
                 const auto b = decompBuffer.GetUint16LE();
                 const auto c = decompBuffer.GetUint16LE();
                 ss << a << " " << b << " " << c;
             } break;
-            case AdsActions::IF_CHAP_GTE:
-            {
-                assert(false);
-            } break;
+            case AdsActions::IF_CHAP_GTE: [[fallthrough]];
             case AdsActions::IF_CHAP_LTE:
             {
-                assert(false);
-            }
-                break;
-            case AdsActions::ELSE:
-                assert(false);
-                break;
+                const auto a = decompBuffer.GetUint16LE();
+                ss << a;
+            } break;
+            case AdsActions::STOP_SCENE:
+            {
+                const auto a = decompBuffer.GetUint16LE();
+                ss << a;
+            } break;
+            case AdsActions::ELSE: [[fallthrough]];
             // Currently only chapter conditions are implemented
             // so and and or are not implemented...
             case AdsActions::AND: [[fallthrough]];
-            case AdsActions::OR: [[fallthrough]];
-            case AdsActions::FADE_OUT: [[fallthrough]];
-            case AdsActions::END_IF:
+            case AdsActions::OR:
                 break;
         }
 
@@ -357,7 +359,7 @@ std::unordered_map<unsigned, std::vector<SceneSequence>> LoadSceneSequences(File
 
 namespace {
 
-std::vector<SceneAction> DecodeTTM(FileBuffer& fb, Tags& tags)
+std::vector<ScriptAction> DecodeTTM(FileBuffer& fb, Tags& tags)
 {
     const auto& logger = Logging::LogState::GetLogger(__FUNCTION__);
 
@@ -390,7 +392,7 @@ std::vector<SceneAction> DecodeTTM(FileBuffer& fb, Tags& tags)
 
     const auto offset = 8 * 3 + pageBuffer.GetSize() + versionBuffer.GetSize() + 5;
 
-    std::vector<SceneAction> actions{};
+    std::vector<ScriptAction> actions{};
 
     bool flipped = false;
     unsigned activeEdgeColor = 0xf;
@@ -421,7 +423,7 @@ std::vector<SceneAction> DecodeTTM(FileBuffer& fb, Tags& tags)
 
             const auto tag = tags.FindTag(*name);
             actions.emplace_back(
-                SetScene{
+                SetScript{
                     *name,
                     tag
                         ? static_cast<std::uint16_t>(tag->mValue)
@@ -475,8 +477,8 @@ std::vector<SceneAction> DecodeTTM(FileBuffer& fb, Tags& tags)
             case Actions::SLOT_PALETTE:
                 actions.emplace_back(SlotPalette{static_cast<unsigned>(args[0])});
                 break;
-            case Actions::SET_SCENEA: [[fallthrough]];
-            case Actions::SET_SCENE:
+            case Actions::SET_SCRIPTA: [[fallthrough]];
+            case Actions::SET_SCRIPT:
             {
                 ASSERT(!args.empty());
                 const auto tag = tags.GetTag(Tag{static_cast<unsigned>(args[0])});
@@ -484,7 +486,7 @@ std::vector<SceneAction> DecodeTTM(FileBuffer& fb, Tags& tags)
                     ? *tag
                     : std::to_string(static_cast<int>(args[0]));
                 actions.emplace_back(
-                    SetScene{
+                    SetScript{
                         sceneTag,
                         static_cast<std::uint16_t>(args[0])});
             } break;
@@ -601,14 +603,14 @@ std::vector<SceneAction> DecodeTTM(FileBuffer& fb, Tags& tags)
 
 }
 
-std::unordered_map<unsigned, Scene> LoadScenes(FileBuffer& fb)
+std::unordered_map<unsigned, Script> LoadScripts(FileBuffer& fb)
 {
     Tags tags{};
     const auto actions = DecodeTTM(fb, tags);
 
-    std::unordered_map<unsigned, Scene> scenes{};
+    std::unordered_map<unsigned, Script> scripts{};
 
-    Scene currentScene;
+    Script currentScript;
     bool loadingScene = false;
     std::optional<unsigned> imageSlot = 0;
     std::optional<PaletteSlot> paletteSlot{};
@@ -625,24 +627,24 @@ std::unordered_map<unsigned, Scene> LoadScenes(FileBuffer& fb)
         unsigned,
         std::pair<std::string, unsigned>> screens{};
 
-    const auto PushScene = [&]{
-        currentScene.mPalettes = palettes;
-        currentScene.mImages.clear();
+    const auto PushScript = [&]{
+        currentScript.mPalettes = palettes;
+        currentScript.mImages.clear();
         for (auto [key, val] : images)
         {
-            if (!currentScene.mPalettes.contains(val.second))
+            if (!currentScript.mPalettes.contains(val.second))
             {
                 val = std::make_pair(val.first, 0);
             }
-            currentScene.mImages[key] = val;
+            currentScript.mImages[key] = val;
         }
-        currentScene.mScreens = screens;
-        currentScene.mActions.emplace_back(DisableClipRegion{});
+        currentScript.mScreens = screens;
+        currentScript.mActions.emplace_back(DisableClipRegion{});
 
-        const auto tag = tags.FindTag(currentScene.mSceneTag);
+        const auto tag = tags.FindTag(currentScript.mSceneTag);
         if (tag)
         {
-            scenes[tag->mValue] = currentScene;
+            scripts[tag->mValue] = currentScript;
         }
         else
         {
@@ -654,16 +656,16 @@ std::unordered_map<unsigned, Scene> LoadScenes(FileBuffer& fb)
     {
         std::visit(
             overloaded{
-                [&](const SetScene& setScene)
+                [&](const SetScript& setScript)
                 {
                     if (loadingScene)
-                        PushScene();
+                        PushScript();
 
-                    currentScene.mSceneTag = setScene.mName;
-                    currentScene.mActions.clear();
-                    currentScene.mImages.clear();
-                    currentScene.mScreens.clear();
-                    currentScene.mPalettes.clear();
+                    currentScript.mSceneTag = setScript.mName;
+                    currentScript.mActions.clear();
+                    currentScript.mImages.clear();
+                    currentScript.mScreens.clear();
+                    currentScript.mPalettes.clear();
                     images.clear();
                     imageSlots.clear();
                     palettes.clear();
@@ -711,43 +713,43 @@ std::unordered_map<unsigned, Scene> LoadScenes(FileBuffer& fb)
                 },
                 [&](const ClipRegion& a)
                 {
-                    currentScene.mActions.emplace_back(a);
+                    currentScript.mActions.emplace_back(a);
                 },
                 [&](const DrawScreen& a)
                 {
-                    currentScene.mActions.emplace_back(a);
+                    currentScript.mActions.emplace_back(a);
                 },
                 [&](const DrawRect& a)
                 {
-                    currentScene.mActions.emplace_back(a);
+                    currentScript.mActions.emplace_back(a);
                 },
                 [&](const DrawSprite& a)
                 {
-                    currentScene.mActions.emplace_back(a);
+                    currentScript.mActions.emplace_back(a);
                 },
                 [&](const Update& a)
                 {
-                    currentScene.mActions.emplace_back(a);
+                    currentScript.mActions.emplace_back(a);
                 },
                 [&](const Purge& a)
                 {
-                    currentScene.mActions.emplace_back(a);
+                    currentScript.mActions.emplace_back(a);
                 },
                 [&](const Delay& a)
                 {
-                    currentScene.mActions.emplace_back(a);
+                    currentScript.mActions.emplace_back(a);
                 },
                 [](const auto&){}},
             action);
     }
 
     // Push final scene
-    PushScene();
+    PushScript();
 
-    return scenes;
+    return scripts;
 }
 
-std::vector<SceneAction> LoadDynamicScenes(FileBuffer& fb)
+std::vector<ScriptAction> LoadDynamicScripts(FileBuffer& fb)
 {
     Tags tags{};
     return DecodeTTM(fb, tags);

--- a/bak/scene/scene.hpp
+++ b/bak/scene/scene.hpp
@@ -36,15 +36,14 @@ struct SceneIndex
 
 struct SceneADS
 {
-    unsigned mInitScene;
-    unsigned mDrawScene;
-    bool mPlayAllScenes;
+    unsigned mTTMSlot;
+    unsigned mScriptTag;
 };
 
 struct SceneSequence
 {
     std::string mName;
-    std::vector<SceneADS> mScenes;
+    std::vector<SceneADS> mScripts;
 };
 
 std::ostream& operator<<(std::ostream&, const SceneIndex&);
@@ -57,10 +56,10 @@ struct ImageSlot
 
 using PaletteSlot = unsigned;
 
-struct Scene
+struct Script
 {
     std::string mSceneTag;
-    std::vector<SceneAction> mActions;
+    std::vector<ScriptAction> mActions;
     std::unordered_map<PaletteSlot, std::string> mPalettes;
     std::unordered_map<unsigned, std::pair<std::string, PaletteSlot>> mImages;
     std::unordered_map<PaletteSlot, std::pair<std::string, PaletteSlot>> mScreens;
@@ -68,18 +67,18 @@ struct Scene
     std::optional<ClipRegion> mClipRegion;
 };
 
-std::ostream& operator<<(std::ostream&, const Scene&);
+std::ostream& operator<<(std::ostream&, const Script&);
 
 struct DynamicScene
 {
-    std::map<unsigned, unsigned> mScenes;
-    std::vector<SceneAction> mActions;
+    std::map<unsigned, unsigned> mScripts;
+    std::vector<ScriptAction> mActions;
 };
 
 std::unordered_map<unsigned, std::vector<SceneSequence>> LoadSceneSequences(FileBuffer& fb);
 std::unordered_map<unsigned, SceneIndex> LoadSceneIndices(FileBuffer& fb);
-std::unordered_map<unsigned, Scene> LoadScenes(FileBuffer& fb);
-std::vector<SceneAction> LoadDynamicScenes(FileBuffer& fb);
+std::unordered_map<unsigned, Script> LoadScripts(FileBuffer& fb);
+std::vector<ScriptAction> LoadDynamicScripts(FileBuffer& fb);
 
 FileBuffer DecompressTTM(FileBuffer& fb);
 

--- a/bak/scene/sceneData.cpp
+++ b/bak/scene/sceneData.cpp
@@ -12,21 +12,20 @@ std::string_view ToString(AdsActions a)
 {
     switch (a)
     {
-    case AdsActions::INDEX: return "Index";
     case AdsActions::IF_NOT_PLAYED: return "IfNotPlayed";
-    case AdsActions::IF_PLAYED: return "IfPlayed";
+    case AdsActions::IF_NOT_PLAYED_ELSE: return "IfNotPlayedElse";
+    case AdsActions::IF_PLAYED_ELSE: return "IfPlayedElse";
     case AdsActions::IF_CHAP_LTE: return "IfChapterLTE";
     case AdsActions::ELSE: return "Else";
     case AdsActions::IF_CHAP_GTE: return "IfChapterGTE";
     case AdsActions::AND: return "And";
     case AdsActions::OR: return "Or";
-    case AdsActions::ADD_SCENE2: return "AddScene2";
-    case AdsActions::ADD_SCENE: return "AddScene";
-    case AdsActions::STOP_SCENE: return "StopScene";
-    case AdsActions::PLAY_SCENE: return "PlayScene";
-    case AdsActions::PLAY_ALL_SCENES: return "PlayAllScenes";
-    case AdsActions::FADE_OUT: return "FadeOut";
+    case AdsActions::RESTART_SCRIPT: return "RestartScript";
+    case AdsActions::START_SCRIPT: return "StartScript";
+    case AdsActions::STOP_SCRIPT: return "StopScript";
+    case AdsActions::END_IF_ELSE: return "EndIfElse";
     case AdsActions::END_IF: return "EndIf";
+    case AdsActions::STOP_SCENE: return "StopScene";
     case AdsActions::END: return "End";
     default:
         std::stringstream ss{};
@@ -57,8 +56,8 @@ std::string_view ToString(Actions a)
     case Actions::SLOT_IMAGE: return "SlotImage";
     case Actions::SLOT_PALETTE: return "SlotPalette";
     case Actions::SLOT_FONT: return "SlotFont";
-    case Actions::SET_SCENE: return "SetScene";
-    case Actions::SET_SCENEA: return "SETSCENEA";
+    case Actions::SET_SCRIPT: return "SetScript";
+    case Actions::SET_SCRIPTA: return "SETSCRIPTA";
     case Actions::SET_SAVE_LAYER: return "SetSaveLayer";
     case Actions::GOTO_TAG: return "GotoTag";
     case Actions::SET_COLOR: return "SetColors";
@@ -110,9 +109,9 @@ std::ostream& operator<<(std::ostream& os, Actions a)
     return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const SetScene& ss)
+std::ostream& operator<<(std::ostream& os, const SetScript& ss)
 {
-    os << "SetScene {" << ss.mSceneNumber << " " << ss.mName << "}";
+    os << "SetScript {" << ss.mScriptNumber << " " << ss.mName << "}";
     return os;
 }
 
@@ -260,7 +259,7 @@ std::ostream& operator<<(std::ostream& os, const GotoTag& a)
     return os << "GotoTag{ " << a.mTag << "}";
 }
 
-std::ostream& operator<<(std::ostream& os, const SceneAction& sa)
+std::ostream& operator<<(std::ostream& os, const ScriptAction& sa)
 {
     std::visit(overloaded{
         [&](const auto& x){ os << x; }},

--- a/bak/scene/sceneData.hpp
+++ b/bak/scene/sceneData.hpp
@@ -12,22 +12,21 @@ namespace BAK {
 
 enum class AdsActions
 {
-    INDEX           = 0x1030,
-    IF_NOT_PLAYED   = 0x1330,
-    IF_PLAYED       = 0x1350,
-    IF_CHAP_LTE     = 0x13a0,
-    IF_CHAP_GTE     = 0x13b0,
-    AND             = 0x1420,
-    OR              = 0x1430,
-    ELSE            = 0x1500,
-    ADD_SCENE2      = 0x2000,
-    ADD_SCENE       = 0x2005,
-    STOP_SCENE      = 0x2010,
-    PLAY_SCENE      = 0x1510,
-    PLAY_ALL_SCENES = 0x1520,
-    FADE_OUT        = 0xf010,
-    END_IF          = 0xfff0,
-    END             = 0xffff
+    IF_NOT_PLAYED      = 0x1030,
+    IF_NOT_PLAYED_ELSE = 0x1330,
+    IF_PLAYED_ELSE     = 0x1350,
+    IF_CHAP_LTE        = 0x13a0,
+    IF_CHAP_GTE        = 0x13b0,
+    AND                = 0x1420,
+    OR                 = 0x1430,
+    ELSE               = 0x1500,
+    END_IF_ELSE        = 0x1510,
+    END_IF             = 0x1520,
+    RESTART_SCRIPT     = 0x2000,
+    START_SCRIPT       = 0x2005,
+    STOP_SCRIPT        = 0x2010,
+    STOP_SCENE         = 0xf010,
+    END                = 0xffff
 };
 
 std::string_view ToString(AdsActions a);
@@ -52,8 +51,8 @@ enum class Actions
     SLOT_IMAGE          = 0x1050,
     SLOT_PALETTE        = 0x1060,
     SLOT_FONT           = 0x1070,
-    SET_SCENEA          = 0x1100, // Local taG?
-    SET_SCENE           = 0x1110, // TAG??
+    SET_SCRIPTA          = 0x1100, // Local taG?
+    SET_SCRIPT           = 0x1110, // TAG??
     SET_SAVE_LAYER      = 0x1120,
     GOTO_TAG            = 0x1200,
     SET_COLOR           = 0x2000,
@@ -95,13 +94,13 @@ enum class Actions
 std::string_view ToString(Actions a);
 std::ostream& operator<<(std::ostream&, Actions);
 
-struct SetScene
+struct SetScript
 {
     std::string mName;
-    std::uint16_t mSceneNumber;
+    std::uint16_t mScriptNumber;
 };
 
-std::ostream& operator<<(std::ostream&, const SetScene&);
+std::ostream& operator<<(std::ostream&, const SetScript&);
 
 struct LoadScreen
 { 
@@ -260,7 +259,7 @@ struct ShowDialog
     unsigned mDialogType;
 };
 
-using SceneAction = std::variant<
+using ScriptAction = std::variant<
     ClearScreen,
     ClipRegion,
     Delay,
@@ -278,7 +277,7 @@ using SceneAction = std::variant<
     FadeOut,
     FadeIn,
     LoadScreen,
-    SetScene,
+    SetScript,
     SetColors,
     SlotImage,
     SetSaveLayer,
@@ -289,6 +288,6 @@ using SceneAction = std::variant<
     GotoTag,
     SlotPalette>;
 
-std::ostream& operator<<(std::ostream& os, const SceneAction& sa);
+std::ostream& operator<<(std::ostream& os, const ScriptAction& sa);
 
 }

--- a/bak/scene/ttmRunner.cpp
+++ b/bak/scene/ttmRunner.cpp
@@ -22,16 +22,16 @@ void TTMRunner::LoadTTM(
     auto adsFb = FileBufferFactory::Get().CreateDataBuffer(adsFile);
     mSceneSequences = LoadSceneSequences(adsFb);
     auto ttmFb = FileBufferFactory::Get().CreateDataBuffer(ttmFile);
-    mActions = LoadDynamicScenes(ttmFb);
+    mActions = LoadDynamicScripts(ttmFb);
 
     mCurrentSequence = 0;
     mCurrentSequenceScene = 0;
-    auto nextTag = mSceneSequences[1][mCurrentSequence].mScenes[mCurrentSequenceScene].mDrawScene;
+    auto nextTag = mSceneSequences[1][mCurrentSequence].mScripts[mCurrentSequenceScene].mScriptTag;
     mLogger.Debug() << "Next tag: " << nextTag << "\n";
     mCurrentAction = FindActionMatchingTag(nextTag);
 }
 
-std::optional<SceneAction> TTMRunner::GetNextAction()
+std::optional<ScriptAction> TTMRunner::GetNextAction()
 {
     if (mCurrentAction == mActions.size())
     {
@@ -85,7 +85,7 @@ std::optional<SceneAction> TTMRunner::GetNextAction()
 
 void TTMRunner::AdvanceToNextScene()
 {
-    auto& currentScenes = mSceneSequences[1][mCurrentSequence].mScenes;
+    auto& currentScenes = mSceneSequences[1][mCurrentSequence].mScripts;
     mCurrentSequenceScene++;
     if (mCurrentSequenceScene == currentScenes.size())
     {
@@ -100,7 +100,7 @@ void TTMRunner::AdvanceToNextScene()
         return;
     }
 
-    auto nextTag = mSceneSequences[1][mCurrentSequence].mScenes[mCurrentSequenceScene].mDrawScene;
+    auto nextTag = mSceneSequences[1][mCurrentSequence].mScripts[mCurrentSequenceScene].mScriptTag;
     mCurrentAction = FindActionMatchingTag(nextTag);
 }
 
@@ -109,8 +109,8 @@ unsigned TTMRunner::FindActionMatchingTag(unsigned tag)
     std::optional<unsigned> foundIndex{};
     for (unsigned i = 0; i < mActions.size(); i++)
     {
-        evaluate_if<SetScene>(mActions[i], [&](const auto& action) {
-            if (action.mSceneNumber == tag)
+        evaluate_if<SetScript>(mActions[i], [&](const auto& action) {
+            if (action.mScriptNumber == tag)
             {
                 foundIndex = i;
             }

--- a/bak/scene/ttmRunner.hpp
+++ b/bak/scene/ttmRunner.hpp
@@ -19,14 +19,14 @@ public:
         std::string adsFile,
         std::string ttmFile);
 
-    std::optional<SceneAction> GetNextAction();
+    std::optional<ScriptAction> GetNextAction();
 
 private:
     void AdvanceToNextScene();
     unsigned FindActionMatchingTag(unsigned tag);
 
     std::unordered_map<unsigned, std::vector<SceneSequence>> mSceneSequences;
-    std::vector<SceneAction> mActions;
+    std::vector<ScriptAction> mActions;
 
     unsigned mCurrentAction = 0;
     unsigned mCurrentSequence = 0;

--- a/build.sh
+++ b/build.sh
@@ -2,10 +2,34 @@
 
 # This script assumes you have ninja installed. If not please remove -GNinja, and simply invoke this with make.
 
+OFFLINE_FLAGS=""
 
-mkdir build
+DEPS_DIR=$HOME/Code/deps
+
+for arg in "$@"; do
+    case "$arg" in
+        --offline|-o)
+            OFFLINE_FLAGS=" \
+    -DFETCHCONTENT_FULLY_DISCONNECTED=ON \
+    -DFETCHCONTENT_SOURCE_DIR_GLM=$DEPS_DIR/glm \
+    -DFETCHCONTENT_SOURCE_DIR_GLFW=$DEPS_DIR/glfw \
+    -DFETCHCONTENT_SOURCE_DIR_LUA=$DEPS_DIR/lua \
+    -DFETCHCONTENT_SOURCE_DIR_LUABRIDGE3=$DEPS_DIR/LuaBridge3 \
+    -DFETCHCONTENT_SOURCE_DIR_GOOGLETEST=$DEPS_DIR/googletest \
+    -DFETCHCONTENT_SOURCE_DIR_AUDIOCODECS=$DEPS_DIR/AudioCodecs \
+    -DFETCHCONTENT_SOURCE_DIR_SDLMIXERX=$DEPS_DIR/SDL-Mixer-X \
+    "
+            ;;
+        *)
+            echo "Unknown option: $arg" >&2
+            exit 1
+            ;;
+    esac
+done
+
+mkdir -p build
 cd build
-cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -GNinja ..
+cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -GNinja $OFFLINE_FLAGS ..
 ln -sf $(pwd)/compile_commands.json $(pwd)/../compile_commands.json
 
 ninja

--- a/gui/gdsScene.cpp
+++ b/gui/gdsScene.cpp
@@ -106,9 +106,9 @@ GDSScene::GDSScene(
         mGameState.SetShopType_7542(shopStats.mRepairTypes);
     }
 
-    const auto& scene1 = mSceneHotspots.GetScene(
+    const auto& scene1 = mSceneHotspots.GetScript(
         mSceneHotspots.mSceneIndex1, mGameState);
-    const auto& scene2 = mSceneHotspots.GetScene(
+    const auto& scene2 = mSceneHotspots.GetScript(
         mSceneHotspots.mSceneIndex2, mGameState);
 
     // Unlikely we ever nest this deep
@@ -221,9 +221,9 @@ void GDSScene::HandleHotspotLeftClicked(const BAK::Hotspot& hotspot, bool hotspo
     {
         if (hotspot.mActionArg2 != 0)
         {
-            const auto& scene1 = mSceneHotspots.GetScene(
+            const auto& scene1 = mSceneHotspots.GetScript(
                 mSceneHotspots.mSceneIndex1, mGameState);
-            const auto& scene2 = mSceneHotspots.GetScene(
+            const auto& scene2 = mSceneHotspots.GetScript(
                 hotspot.mActionArg2, mGameState);
             AddStaticTTM(scene1, scene2);
         }
@@ -327,7 +327,7 @@ void GDSScene::DialogFinished(const std::optional<BAK::ChoiceIndex>& choice)
     EvaluateHotspotAction();
 }
 
-void GDSScene::AddStaticTTM(BAK::Scene scene1, BAK::Scene scene2)
+void GDSScene::AddStaticTTM(BAK::Script scene1, BAK::Script scene2)
 {
     ASSERT(mStaticTTMs.size () < mMaxSceneNesting);
     mLogger.Debug() << __FUNCTION__ << " " << scene1 << " --- " << scene2 << " \n";
@@ -539,9 +539,9 @@ void GDSScene::DoTemple(BAK::KeyTarget target)
     auto* container = mGameState.GetContainerForGDSScene(mReference);
     ASSERT(container && container->IsShop());
     assert(mSceneHotspots.GetTempleNumber());
-    const auto& scene1 = mSceneHotspots.GetScene(
+    const auto& scene1 = mSceneHotspots.GetScript(
         mSceneHotspots.mSceneIndex1, mGameState);
-    const auto& scene2 = mSceneHotspots.GetScene(
+    const auto& scene2 = mSceneHotspots.GetScript(
         3, mGameState);
     AddStaticTTM(scene1, scene2);
     mDialogDisplay.Clear();

--- a/gui/gdsScene.hpp
+++ b/gui/gdsScene.hpp
@@ -55,7 +55,7 @@ public:
 
     void StartDialog(BAK::Target target, bool isTooltip);
     void DialogFinished(const std::optional<BAK::ChoiceIndex>&) override;
-    void AddStaticTTM(BAK::Scene scene1, BAK::Scene scene2);
+    void AddStaticTTM(BAK::Script scene1, BAK::Script scene2);
 
     void EvaluateHotspotAction();
 

--- a/gui/scene.cpp
+++ b/gui/scene.cpp
@@ -2,7 +2,7 @@
 
 namespace Gui {
 
-EnableClipRegion ConvertSceneAction(
+EnableClipRegion ConvertScriptAction(
     const BAK::ClipRegion& clip)
 {
     const auto width  = clip.mBottomRight.x - clip.mTopLeft.x;
@@ -16,7 +16,7 @@ EnableClipRegion ConvertSceneAction(
     };
 }
 
-DisableClipRegion ConvertSceneAction(
+DisableClipRegion ConvertScriptAction(
     const BAK::DisableClipRegion&)
 {
     return DisableClipRegion{};

--- a/gui/scene.hpp
+++ b/gui/scene.hpp
@@ -38,12 +38,12 @@ using DrawingAction = std::variant<
     SceneSprite,
     SceneRect>;
 
-DrawingAction ConvertSceneAction(const BAK::SceneAction& action);
-EnableClipRegion ConvertSceneAction(const BAK::ClipRegion&);
-DisableClipRegion ConvertSceneAction(const BAK::DisableClipRegion&);
+DrawingAction ConvertScriptAction(const BAK::ScriptAction& action);
+EnableClipRegion ConvertScriptAction(const BAK::ClipRegion&);
+DisableClipRegion ConvertScriptAction(const BAK::DisableClipRegion&);
 
 template <typename T, typename S>
-SceneSprite ConvertSceneAction(
+SceneSprite ConvertScriptAction(
     const BAK::DrawScreen& action,
     const T& textures,
     const S& offsets) // make this const
@@ -60,7 +60,7 @@ SceneSprite ConvertSceneAction(
         scale};
 }
 template <typename T, typename S>
-SceneSprite ConvertSceneAction(
+SceneSprite ConvertScriptAction(
     const BAK::DrawSprite& action,
     const T& textures,
     const S& offsets) // make this const
@@ -96,7 +96,7 @@ SceneSprite ConvertSceneAction(
 }
 
 template <typename T>
-SceneSprite ConvertSceneAction(
+SceneSprite ConvertScriptAction(
     const BAK::DrawSprite& action,
     const T& textures)
 {

--- a/gui/staticTTM.cpp
+++ b/gui/staticTTM.cpp
@@ -18,8 +18,8 @@ namespace Gui {
 
 StaticTTM::StaticTTM(
     Graphics::SpriteManager& spriteManager,
-    const BAK::Scene& sceneInit,
-    const BAK::Scene& sceneContent)
+    const BAK::Script& sceneInit,
+    const BAK::Script& sceneContent)
 :
     mSpriteSheet{spriteManager.AddTemporarySpriteSheet()},
     mSceneFrame{
@@ -115,7 +115,7 @@ StaticTTM::StaticTTM(
                 overloaded{
                     [&](const BAK::DrawScreen& sa){
                         mLogger.Info() << "DrawScreen: " << sa << "\n";
-                        const auto screen = ConvertSceneAction(
+                        const auto screen = ConvertScriptAction(
                             sa,
                             textures,
                             offsets);
@@ -139,7 +139,7 @@ StaticTTM::StaticTTM(
                             mSceneFrame.AddChildBack(&elem);
                     },
                     [&](const BAK::DrawSprite& sa){
-                        const auto sceneSprite = ConvertSceneAction(
+                        const auto sceneSprite = ConvertScriptAction(
                             sa,
                             textures,
                             offsets);
@@ -185,7 +185,7 @@ StaticTTM::StaticTTM(
                         }
                     },
                     [&](const BAK::ClipRegion& a){
-                        const auto clip = ConvertSceneAction(a);
+                        const auto clip = ConvertScriptAction(a);
                         mClipRegion.emplace(
                             ClipRegionTag{},
                             clip.mTopLeft,

--- a/gui/staticTTM.hpp
+++ b/gui/staticTTM.hpp
@@ -19,8 +19,8 @@ class StaticTTM
 public:
     StaticTTM(
         Graphics::SpriteManager& spriteManager,
-        const BAK::Scene& sceneInit,
-        const BAK::Scene& sceneContent);
+        const BAK::Script& sceneInit,
+        const BAK::Script& sceneContent);
 
     Widget* GetScene();
     Widget* GetBackground();


### PR DESCRIPTION
Rename some of the actions to reflect their actual intention as used by the game and update the terminology of the TTM "Scene" to "Script" to better reflect that they are essentially small programs.