### PR TITLE
Issue #78 - Add cleaner ADS datamodel

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -26,7 +26,7 @@ list(APPEND APP_BINARIES
     display_tbl
     display_tile
     #display_traps
-    display_ttm
+    display_script
     extractor
     #instancing
     image_extractor

--- a/app/display_script.cpp
+++ b/app/display_script.cpp
@@ -1,5 +1,6 @@
 #include "bak/scene/scene.hpp"
 #include "bak/scene/sceneData.hpp"
+#include "bak/scene/ads.hpp"
 
 #include "bak/fileBufferFactory.hpp"
 
@@ -13,7 +14,8 @@ int main(int argc, char** argv)
 
     if (argc < 3)
     {
-        std::cerr << "Usage: " << argv[0] << " <ads|sequences|ttm|dynamic> FILE\n";
+        std::cerr << "Usage: " << argv[0]
+            << " <ads|sequences|ttm|dynamic|rawads|rawttm|schedule> FILE\n";
         return -1;
     }
 
@@ -58,6 +60,19 @@ int main(int argc, char** argv)
         {
             std::cout << action << "\n";
         }
+    }
+    else if (mode == "rawads")
+    {
+        BAK::DumpADS(fb, std::cout);
+    }
+    else if (mode == "rawttm")
+    {
+        BAK::DumpTTM(fb, std::cout);
+    }
+    else if (mode == "schedule")
+    {
+        const auto ads = BAK::ADS::LoadAds(fb);
+        std::cout << ads;
     }
     else
     {

--- a/bak/CMakeLists.txt
+++ b/bak/CMakeLists.txt
@@ -68,6 +68,7 @@ add_library(bak
     saveManager.hpp saveManager.cpp
     scene/scene.hpp scene/scene.cpp
     scene/sceneData.hpp scene/sceneData.cpp
+    scene/ads.hpp scene/ads.cpp
     screen.hpp screen.cpp
     shop.hpp shop.cpp
     skills.hpp skills.cpp

--- a/bak/scene/ads.cpp
+++ b/bak/scene/ads.cpp
@@ -1,0 +1,312 @@
+#include "bak/scene/ads.hpp"
+
+#include "bak/scene/scene.hpp"
+#include "bak/scene/sceneData.hpp"
+#include "bak/file/fileBuffer.hpp"
+#include "bak/tags.hpp"
+#include "bak/dataTags.hpp"
+
+#include "com/assert.hpp"
+#include "com/logger.hpp"
+#include "com/visit.hpp"
+
+#include <cstdint>
+#include <ostream>
+#include <vector>
+
+namespace BAK::ADS {
+
+namespace {
+
+struct RawOp
+{
+    AdsActions mOp;
+    std::vector<std::uint16_t> mArgs;
+};
+
+unsigned OperandCount(AdsActions op)
+{
+    switch (op)
+    {
+        case AdsActions::IF_NOT_PLAYED:
+        case AdsActions::IF_NOT_PLAYED_ELSE:
+        case AdsActions::IF_PLAYED_ELSE:
+            return 2;
+        case AdsActions::RESTART_SCRIPT:
+        case AdsActions::START_SCRIPT:
+            return 4;
+        case AdsActions::STOP_SCRIPT:
+            return 3;
+        case AdsActions::IF_CHAP_GTE:
+        case AdsActions::IF_CHAP_LTE:
+        case AdsActions::STOP_SCENE:
+            return 1;
+        default:
+            return 0;
+    }
+}
+
+bool IsCondition(AdsActions op)
+{
+    switch (op)
+    {
+        case AdsActions::IF_NOT_PLAYED:
+        case AdsActions::IF_NOT_PLAYED_ELSE:
+        case AdsActions::IF_PLAYED_ELSE:
+        case AdsActions::IF_CHAP_GTE:
+        case AdsActions::IF_CHAP_LTE:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool IsAction(AdsActions op)
+{
+    switch (op)
+    {
+        case AdsActions::START_SCRIPT:
+        case AdsActions::RESTART_SCRIPT:
+        case AdsActions::STOP_SCRIPT:
+            return true;
+        default:
+            return false;
+    }
+}
+
+Condition MakeCondition(const RawOp& op)
+{
+    switch (op.mOp)
+    {
+        case AdsActions::IF_NOT_PLAYED:
+        case AdsActions::IF_NOT_PLAYED_ELSE:
+            return NotStarted{ScriptIndex{op.mArgs[1]}};
+        case AdsActions::IF_PLAYED_ELSE:
+            return Finished{ScriptIndex{op.mArgs[1]}};
+        case AdsActions::IF_CHAP_GTE:
+            return ChapterGTE{op.mArgs[0]};
+        case AdsActions::IF_CHAP_LTE:
+            return ChapterLTE{op.mArgs[0]};
+        default:
+            ASSERT(false);
+            return NotStarted{ScriptIndex{0}};
+    }
+}
+
+Action MakeAction(const RawOp& op)
+{
+    switch (op.mOp)
+    {
+        case AdsActions::START_SCRIPT:
+        // Only used by LAMUT, effectively same as Start..
+        case AdsActions::RESTART_SCRIPT:
+            return StartScript{ScriptIndex{op.mArgs[1]}};
+        case AdsActions::STOP_SCRIPT:
+            return StopScript{ScriptIndex{op.mArgs[1]}};
+        default:
+            ASSERT(false);
+            return StartScript{ScriptIndex{0}};
+    }
+}
+
+class Parser
+{
+public:
+    Parser(const std::vector<RawOp>& ops)
+    :
+        mOps{ops},
+        mPos{0}
+    {}
+
+    std::vector<ActionBlock> ParseBlocks()
+    {
+        std::vector<ActionBlock> blocks;
+        while (mPos < mOps.size())
+        {
+            blocks.emplace_back(ParseBlock());
+        }
+        return blocks;
+    }
+
+private:
+    const RawOp& Peek() const { return mOps[mPos]; }
+    bool AtEnd() const { return mPos >= mOps.size(); }
+
+    std::vector<Condition> ParseCondition()
+    {
+        std::vector<Condition> condition;
+        condition.emplace_back(MakeCondition(mOps[mPos++]));
+        while (!AtEnd()
+            && (Peek().mOp == AdsActions::AND || Peek().mOp == AdsActions::OR))
+        {
+            // there's no OR in BaK files
+            ASSERT(Peek().mOp == AdsActions::AND);
+            mPos++;
+            condition.emplace_back(MakeCondition(mOps[mPos++]));
+        }
+        return condition;
+    }
+
+    void ParseBody(std::vector<Action>& out)
+    {
+        while (!AtEnd())
+        {
+            const auto op = Peek().mOp;
+            if (IsAction(op))
+            {
+                out.emplace_back(MakeAction(mOps[mPos++]));
+            }
+            else if (IsCondition(op))
+            {
+                ParseCondition();
+                ParseBody(out);
+                if (!AtEnd() && Peek().mOp == AdsActions::ELSE)
+                {
+                    mPos++;
+                    ParseBody(out);
+                }
+                if (!AtEnd()
+                    && (Peek().mOp == AdsActions::END_IF
+                        || Peek().mOp == AdsActions::END_IF_ELSE))
+                {
+                    mPos++;
+                }
+            }
+            else
+            {
+                // ELSE, END_IF, END_IF_ELSE
+                break;
+            }
+        }
+    }
+
+    ActionBlock ParseBlock()
+    {
+        ASSERT(!AtEnd() && IsCondition(Peek().mOp));
+        ActionBlock block;
+        block.mConditions = ParseCondition();
+        ParseBody(block.mThen);
+        if (!AtEnd() && Peek().mOp == AdsActions::ELSE)
+        {
+            mPos++;
+            ParseBody(block.mElse);
+        }
+        if (!AtEnd()
+            && (Peek().mOp == AdsActions::END_IF
+                || Peek().mOp == AdsActions::END_IF_ELSE))
+        {
+            mPos++;
+        }
+        return block;
+    }
+
+    const std::vector<RawOp>& mOps;
+    std::size_t mPos;
+};
+
+}
+
+std::ostream& operator<<(std::ostream& os, const Action& a)
+{
+    std::visit(overloaded{
+        [&](const StartScript& s){ os << "Start(" << s.mScriptIndex << ")"; },
+        [&](const StopScript& s){ os << "Stop(" << s.mScriptIndex << ")"; }},
+        a);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const Condition& c)
+{
+    std::visit(overloaded{
+        [&](const NotStarted& x){ os << "NotStarted(" << x.mScriptIndex << ")"; },
+        [&](const Finished& x){ os << "Finished(" << x.mScriptIndex << ")"; },
+        [&](const ChapterGTE& x){ os << "ChapterGTE(" << x.mChapter << ")"; },
+        [&](const ChapterLTE& x){ os << "ChapterLTE(" << x.mChapter << ")"; }},
+        c);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const ActionBlock& b)
+{
+    os << "if ";
+    for (unsigned i = 0; i < b.mConditions.size(); i++)
+    {
+        if (i) os << " and ";
+        os << b.mConditions[i];
+    }
+    os << "\n";
+    for (const auto& a : b.mThen)
+    {
+        os << "    " << a << "\n";
+    }
+    if (!b.mElse.empty())
+    {
+        os << "else\n";
+        for (const auto& a : b.mElse)
+        {
+            os << "    " << a << "\n";
+        }
+    }
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const Scene& s)
+{
+    os << "Scene " << s.mSceneIndex << " (" << s.mTag << "):\n";
+    for (const auto& block : s.mBlocks)
+    {
+        os << "  " << block;
+    }
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const Ads& ads)
+{
+    for (const auto& scene : ads.mScenes)
+    {
+        os << scene;
+    }
+    return os;
+}
+
+Ads LoadAds(FileBuffer& fb)
+{
+    auto tagBuffer = fb.Find(DataTag::TAG);
+    Tags tags{};
+    tags.Load(tagBuffer);
+
+    auto buffer = DecompressSCR(fb);
+
+    Ads ads;
+    while (!buffer.AtEnd())
+    {
+        const unsigned index = buffer.GetUint16LE();
+
+        std::vector<RawOp> ops;
+        for (;;)
+        {
+            const auto op = static_cast<AdsActions>(buffer.GetUint16LE());
+            if (op == AdsActions::END)
+            {
+                break;
+            }
+            RawOp raw{op, {}};
+            const auto count = OperandCount(op);
+            for (unsigned i = 0; i < count; i++)
+            {
+                raw.mArgs.emplace_back(buffer.GetUint16LE());
+            }
+            ops.emplace_back(std::move(raw));
+        }
+
+        Parser parser{ops};
+        Scene scene{};
+        scene.mSceneIndex = index;
+        scene.mTag = tags.GetTag(Tag{index}).value_or("");
+        scene.mBlocks = parser.ParseBlocks();
+        ads.mScenes.emplace_back(std::move(scene));
+    }
+    return ads;
+}
+
+}

--- a/bak/scene/ads.hpp
+++ b/bak/scene/ads.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+#include "com/strongType.hpp"
+
+#include <iosfwd>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace BAK {
+class FileBuffer;
+}
+
+namespace BAK::ADS {
+
+using SceneIndex = StrongType<unsigned, struct SceneIndexTag>;
+using ScriptIndex = StrongType<unsigned, struct ScriptIndexTag>;
+
+struct StartScript
+{
+    ScriptIndex mScriptIndex;
+};
+
+struct StopScript
+{
+    ScriptIndex mScriptIndex;
+};
+
+using Action = std::variant<
+    StartScript,
+    StopScript>;
+
+struct NotStarted
+{
+    ScriptIndex mScriptIndex;
+};
+
+struct Finished
+{
+    ScriptIndex mScriptIndex;
+};
+
+struct ChapterGTE
+{
+    unsigned mChapter;
+};
+
+struct ChapterLTE
+{
+    unsigned mChapter;
+};
+
+using Condition = std::variant<
+    NotStarted,
+    Finished,
+    ChapterGTE,
+    ChapterLTE>;
+
+struct ActionBlock
+{
+    std::vector<Condition> mConditions;
+    std::vector<Action> mThen;
+    std::vector<Action> mElse;
+};
+
+struct Scene
+{
+    unsigned mSceneIndex;
+    std::string mTag;
+    std::vector<ActionBlock> mBlocks;
+};
+
+struct Ads
+{
+    std::vector<Scene> mScenes;
+};
+
+std::ostream& operator<<(std::ostream&, const Action&);
+std::ostream& operator<<(std::ostream&, const Condition&);
+std::ostream& operator<<(std::ostream&, const ActionBlock&);
+std::ostream& operator<<(std::ostream&, const Scene&);
+std::ostream& operator<<(std::ostream&, const Ads&);
+
+Ads LoadAds(FileBuffer& fb);
+
+}

--- a/bak/scene/scene.cpp
+++ b/bak/scene/scene.cpp
@@ -11,9 +11,45 @@
 #include "com/string.hpp"
 #include "com/visit.hpp"
 
+#include <sstream>
 #include <unordered_map>
 
 namespace BAK {
+
+FileBuffer DecompressSCR(FileBuffer& fb)
+{
+    auto scrbuf = fb.Find(DataTag::SCR);
+
+    if (scrbuf.GetUint8() != 0x02)
+    {
+        throw std::runtime_error("Script buffer not compressed");
+    }
+
+    auto decompressedSize = scrbuf.GetUint32LE();
+    auto decompBuffer = FileBuffer(decompressedSize);
+    scrbuf.DecompressLZW(&decompBuffer);
+
+    return decompBuffer;
+}
+
+FileBuffer DecompressTT3(FileBuffer& fb)
+{
+    auto tt3Buffer = fb.Find(DataTag::TT3);
+
+    auto compression = tt3Buffer.GetUint8();
+    auto decompressedSize = tt3Buffer.GetUint32LE();
+    auto decompBuffer = FileBuffer(decompressedSize);
+    if (compression == 1)
+    {
+        tt3Buffer.DecompressRLE(&decompBuffer);
+    }
+    else
+    {
+        tt3Buffer.CopyTo(&decompBuffer, decompressedSize);
+    }
+
+    return decompBuffer;
+}
 
 ADSIndex::ADSIndex()
 :
@@ -95,18 +131,10 @@ std::unordered_map<unsigned, SceneIndex> LoadSceneIndices(FileBuffer& fb)
     const auto& logger = Logging::LogState::GetLogger(__FUNCTION__);
 
     auto resbuf = fb.Find(DataTag::RES);
-    auto scrbuf = fb.Find(DataTag::SCR);
     auto tagbuf = fb.Find(DataTag::TAG);
 
-    if (scrbuf.GetUint8() != 0x02)
-    {
-        throw std::runtime_error("Script buffer not compressed");
-    }
+    auto decompBuffer = DecompressSCR(fb);
 
-    auto decompressedSize = scrbuf.GetUint32LE();
-    auto decompBuffer = FileBuffer(decompressedSize);
-    scrbuf.DecompressLZW(&decompBuffer);
-    
     Tags tags{};
     tags.Load(tagbuf);
 
@@ -235,18 +263,10 @@ std::unordered_map<unsigned, std::vector<SceneSequence>> LoadSceneSequences(File
     const auto& logger = Logging::LogState::GetLogger(__FUNCTION__);
 
     auto resbuf = fb.Find(DataTag::RES);
-    auto scrbuf = fb.Find(DataTag::SCR);
     auto tagbuf = fb.Find(DataTag::TAG);
 
-    if (scrbuf.GetUint8() != 0x02)
-    {
-        throw std::runtime_error("Script buffer not compressed");
-    }
+    auto decompBuffer = DecompressSCR(fb);
 
-    auto decompressedSize = scrbuf.GetUint32LE();
-    auto decompBuffer = FileBuffer(decompressedSize);
-    scrbuf.DecompressLZW(&decompBuffer);
-    
     Tags tags{};
     tags.Load(tagbuf);
     tags.DumpTags();
@@ -365,27 +385,14 @@ std::vector<ScriptAction> DecodeTTM(FileBuffer& fb, Tags& tags)
 
     auto pageBuffer    = fb.Find(DataTag::PAG);
     auto versionBuffer = fb.Find(DataTag::VER);
-    auto tt3Buffer     = fb.Find(DataTag::TT3);
     auto tagBuffer     = fb.Find(DataTag::TAG);
 
     const auto pages = pageBuffer.GetUint16LE();
     logger.Debug() << "Pages:" << pages << " size: " << pageBuffer.GetSize() << "\n";
     logger.Debug() << "Version size: " << versionBuffer.GetSize() << "\n";
 
-    auto compression = tt3Buffer.GetUint8();
-    auto decompressedSize = tt3Buffer.GetUint32LE();
-    auto decompBuffer = FileBuffer(decompressedSize);
-    logger.Debug() << "TT3 size: " << decompressedSize << "\n";
-    if (compression == 1)
-    {
-        logger.Debug() << "RLE Compressed\n";
-        tt3Buffer.DecompressRLE(&decompBuffer);
-    }
-    else
-    {
-        logger.Debug() << "No compression\n";
-        tt3Buffer.CopyTo(&decompBuffer, decompressedSize);
-    }
+    auto decompBuffer = DecompressTT3(fb);
+    logger.Debug() << "TT3 size: " << decompBuffer.GetSize() << "\n";
 
     tags.Load(tagBuffer);
     tags.DumpTags();
@@ -813,6 +820,130 @@ FileBuffer DecompressTTM(FileBuffer& fb)
     tagBuffer.CopyTo(&decompressedTTM, tagBuffer.GetSize());
 
     return decompressedTTM;
+}
+
+namespace {
+
+template <typename T>
+std::string ActionName(unsigned code)
+{
+    try
+    {
+        return std::string{ToString(static_cast<T>(code))};
+    }
+    catch (const std::runtime_error&)
+    {
+        std::stringstream ss{};
+        ss << "Unknown(0x" << std::hex << code << std::dec << ")";
+        return ss.str();
+    }
+}
+
+}
+
+void DumpADS(FileBuffer& fb, std::ostream& os)
+{
+    auto decompBuffer = DecompressSCR(fb);
+
+    std::optional<unsigned> currentIndex{};
+    while (!decompBuffer.AtEnd())
+    {
+        if (!currentIndex)
+        {
+            currentIndex = decompBuffer.GetUint16LE();
+            os << "Index: " << *currentIndex << "\n";
+        }
+
+        auto code = decompBuffer.GetUint16LE();
+        auto action = static_cast<AdsActions>(code);
+        os << "\t" << ActionName<AdsActions>(code);
+
+        switch (action)
+        {
+            case AdsActions::IF_NOT_PLAYED: [[fallthrough]];
+            case AdsActions::IF_NOT_PLAYED_ELSE: [[fallthrough]];
+            case AdsActions::IF_PLAYED_ELSE:
+            {
+                os << " " << decompBuffer.GetUint16LE()
+                    << " " << decompBuffer.GetUint16LE();
+            } break;
+            case AdsActions::RESTART_SCRIPT: [[fallthrough]];
+            case AdsActions::START_SCRIPT:
+            {
+                os << " " << decompBuffer.GetUint16LE()
+                    << " " << decompBuffer.GetUint16LE()
+                    << " " << decompBuffer.GetUint16LE()
+                    << " " << decompBuffer.GetUint16LE();
+            } break;
+            case AdsActions::STOP_SCRIPT:
+            {
+                os << " " << decompBuffer.GetUint16LE()
+                    << " " << decompBuffer.GetUint16LE()
+                    << " " << decompBuffer.GetUint16LE();
+            } break;
+            case AdsActions::IF_CHAP_GTE: [[fallthrough]];
+            case AdsActions::IF_CHAP_LTE: [[fallthrough]];
+            case AdsActions::STOP_SCENE:
+            {
+                os << " " << decompBuffer.GetUint16LE();
+            } break;
+            case AdsActions::AND: [[fallthrough]];
+            case AdsActions::OR: [[fallthrough]];
+            case AdsActions::ELSE: [[fallthrough]];
+            case AdsActions::END_IF_ELSE: [[fallthrough]];
+            case AdsActions::END_IF:
+                break;
+            case AdsActions::END:
+                currentIndex.reset();
+                break;
+        }
+
+        os << "\n";
+    }
+}
+
+void DumpTTM(FileBuffer& fb, std::ostream& os)
+{
+    auto tagBuffer = fb.Find(DataTag::TAG);
+    Tags tags{};
+    tags.Load(tagBuffer);
+
+    auto decompBuffer = DecompressTT3(fb);
+
+    while (!decompBuffer.AtEnd())
+    {
+        auto code = decompBuffer.GetUint16LE();
+        auto size = static_cast<unsigned>(code & 0x000f);
+        code &= 0xfff0;
+        auto action = static_cast<Actions>(code);
+
+        os << ActionName<Actions>(code);
+
+        if ((code == 0x1110) && (size == 1))
+        {
+            auto id = decompBuffer.GetUint16LE();
+            const auto name = tags.GetTag(Tag{id});
+            os << " Id: " << id;
+            if (name)
+                os << " Name: " << *name;
+        }
+        else if (size == 0xf)
+        {
+            std::string name = ToUpper(decompBuffer.GetString());
+            os << " Name: " << name;
+            if (decompBuffer.GetBytesLeft() & 1)
+                decompBuffer.Skip(1);
+        }
+        else
+        {
+            os << " args [";
+            for (unsigned i = 0; i < size; i++)
+                os << " " << decompBuffer.GetSint16LE();
+            os << " ]";
+        }
+
+        os << "\n";
+    }
 }
 
 }

--- a/bak/scene/scene.hpp
+++ b/bak/scene/scene.hpp
@@ -80,6 +80,11 @@ std::unordered_map<unsigned, SceneIndex> LoadSceneIndices(FileBuffer& fb);
 std::unordered_map<unsigned, Script> LoadScripts(FileBuffer& fb);
 std::vector<ScriptAction> LoadDynamicScripts(FileBuffer& fb);
 
+FileBuffer DecompressSCR(FileBuffer& fb);
+FileBuffer DecompressTT3(FileBuffer& fb);
 FileBuffer DecompressTTM(FileBuffer& fb);
+
+void DumpADS(FileBuffer& fb, std::ostream& os);
+void DumpTTM(FileBuffer& fb, std::ostream& os);
 
 }

--- a/bak/scene/sceneData.hpp
+++ b/bak/scene/sceneData.hpp
@@ -51,8 +51,8 @@ enum class Actions
     SLOT_IMAGE          = 0x1050,
     SLOT_PALETTE        = 0x1060,
     SLOT_FONT           = 0x1070,
-    SET_SCRIPTA          = 0x1100, // Local taG?
-    SET_SCRIPT           = 0x1110, // TAG??
+    SET_SCRIPTA         = 0x1100, // Local taG?
+    SET_SCRIPT          = 0x1110, // TAG??
     SET_SAVE_LAYER      = 0x1120,
     GOTO_TAG            = 0x1200,
     SET_COLOR           = 0x2000,


### PR DESCRIPTION
The BaK ADS player can have multiple StartAds under one block, this means to start both the referenced TTM scripts simultaneously. Change the datamodel to better reflect this.