### PR TITLE
Issue #78 - Fix krondor palace Katala actor

### DIFF
--- a/bak/scene/scene.cpp
+++ b/bak/scene/scene.cpp
@@ -394,7 +394,9 @@ std::vector<ScriptAction> DecodeTTM(FileBuffer& fb, Tags& tags)
             case Actions::SHOW_DIALOG:
                 actions.emplace_back(
                     ShowDialog{
-                        static_cast<unsigned>(args[0]),
+                        args[0] == -1
+                            ? std::nullopt
+                            : std::optional<unsigned>{static_cast<unsigned>(args[0])},
                         static_cast<unsigned>(args[1])});
                 break;
             case Actions::SET_SAVE_LAYER:
@@ -547,6 +549,10 @@ std::unordered_map<unsigned, Script> LoadScripts(FileBuffer& fb)
                     currentScript.mActions.emplace_back(a);
                 },
                 [&](const DrawSprite& a)
+                {
+                    currentScript.mActions.emplace_back(a);
+                },
+                [&](const ShowDialog& a)
                 {
                     currentScript.mActions.emplace_back(a);
                 },

--- a/bak/scene/sceneData.cpp
+++ b/bak/scene/sceneData.cpp
@@ -1,5 +1,6 @@
 #include "bak/scene/sceneData.hpp"
 
+#include "com/ostream.hpp"
 #include "com/visit.hpp"
 
 #include "graphics/glm.hpp"
@@ -245,8 +246,8 @@ std::ostream& operator<<(std::ostream& os, const SlotPalette& a)
 
 std::ostream& operator<<(std::ostream& os, const ShowDialog& a)
 {
-    return os << "ShowDialog{ " << std::hex << a.mDialogKey << std::dec
-        << " type: " << a.mDialogType << "}";
+    return os << "ShowDialog{ " << std::hex << a.mDialogKey
+        << std::dec << " type: " << a.mDialogType << "}";
 }
 
 std::ostream& operator<<(std::ostream& os, const PlaySoundS& a)

--- a/bak/scene/sceneData.hpp
+++ b/bak/scene/sceneData.hpp
@@ -3,6 +3,7 @@
 #include <glm/glm.hpp>
 
 #include <cstdint>
+#include <optional>
 #include <string>
 
 #include <ostream>
@@ -255,7 +256,7 @@ struct SlotPalette
 
 struct ShowDialog
 {
-    unsigned mDialogKey;
+    std::optional<unsigned> mDialogKey;
     unsigned mDialogType;
 };
 

--- a/gui/dynamicTTM.cpp
+++ b/gui/dynamicTTM.cpp
@@ -203,14 +203,15 @@ bool DynamicTTM::RenderDialog(const BAK::ShowDialog& dialog)
     // mDialogType == 0 - the usual method
     if (dialog.mDialogType == 2)
     {
-        mDisplayBook(dialog.mDialogKey);
+        mDisplayBook(dialog.mDialogKey.value_or(0));
         return true;
     }
 
-    if (dialog.mDialogType != 0xff && dialog.mDialogKey != 0 && dialog.mDialogKey != 0xff)
+    if (dialog.mDialogType != 0xff && dialog.mDialogKey
+        && *dialog.mDialogKey != 0 && *dialog.mDialogKey != 0xff)
     {
         const auto& snippet = BAK::DialogStore::Get().GetSnippet(
-            BAK::DialogSources::GetTTMDialogKey(dialog.mDialogKey));
+            BAK::DialogSources::GetTTMDialogKey(*dialog.mDialogKey));
         auto popup = snippet.GetPopup();
         mLogger.Debug() << "Show snippet;" << snippet << "\n";
         if (popup)

--- a/gui/staticTTM.cpp
+++ b/gui/staticTTM.cpp
@@ -42,7 +42,10 @@ StaticTTM::StaticTTM(
     std::unordered_map<unsigned, unsigned> offsets{};
 
     constexpr auto SCENE_PALETTE_SLOT = 0;
+    constexpr auto ACTOR_IMAGE_SLOT = 1;
     std::optional<BAK::Palette> scenePalette{};
+    std::optional<std::string> scenePaletteName{};
+    std::optional<std::string> actorImageName{};
 
     // Load all the image slots
     for (const auto& scene : {sceneInit, sceneContent})
@@ -51,11 +54,16 @@ StaticTTM::StaticTTM(
         if (scenePal != scene.mPalettes.end())
         {
             scenePalette.emplace(scenePal->second);
+            scenePaletteName = scenePal->second;
         }
 
         for (const auto& [imageKey, imagePal] : scene.mImages)
         {
             const auto& [image, palKey] = imagePal;
+            if (imageKey == ACTOR_IMAGE_SLOT)
+            {
+                actorImageName = image;
+            }
             assert(scene.mPalettes.find(palKey) != scene.mPalettes.end());
             const auto& palette = scene.mPalettes.find(palKey)->second;
             mLogger.Debug() << "Loading image slot: " << imageKey 
@@ -82,6 +90,16 @@ StaticTTM::StaticTTM(
         }
     }
 
+    std::optional<unsigned> actorSprite{};
+    if (actorImageName && scenePaletteName)
+    {
+        actorSprite = textures.GetTextures().size();
+        BAK::TextureFactory::AddToTextureStore(
+            textures,
+            *actorImageName,
+            *scenePaletteName);
+    }
+
     // Make sure all the refs are constant
     mSceneElements.reserve(
         sceneInit.mActions.size()
@@ -106,11 +124,11 @@ StaticTTM::StaticTTM(
         );
     }
 
-    // Add widgets for each scene action
     for (const auto& scene : {sceneInit, sceneContent})
     {
         for (const auto& action : scene.mActions)
         {
+            mLogger.Debug() << " Action: " << action << "\n";
             std::visit(
                 overloaded{
                     [&](const BAK::DrawScreen& sa){
@@ -197,6 +215,32 @@ StaticTTM::StaticTTM(
                         // Doesn't really do anything...
                         // in the future maybe pop the clip region
                         // so we could add another one?
+                    },
+                    [&](const BAK::ShowDialog& sd){
+                        // ShowDialog with key -1 draws the actor image
+                        // rather than showing a dialog. Seems to be
+                        // restricted to static TTMs.
+                        if (sd.mDialogKey || !actorSprite)
+                            return;
+                        const auto sprite = *actorSprite;
+                        const auto tex = textures.GetTexture(sprite);
+                        const auto width = static_cast<int>(tex.GetTargetWidth());
+                        const auto height = static_cast<int>(tex.GetTargetHeight());
+
+                        auto& elem = mSceneElements.emplace_back(
+                            Graphics::DrawMode::Sprite,
+                            mSpriteSheet->mSpriteSheet,
+                            Graphics::TextureIndex{sprite},
+                            Graphics::ColorMode::Texture,
+                            glm::vec4{1},
+                            glm::vec2{160 - width / 2, 112 - height},
+                            glm::vec2{width, height},
+                            false);
+
+                        if (mClipRegion)
+                            mClipRegion->AddChildBack(&elem);
+                        else
+                            mSceneFrame.AddChildBack(&elem);
                     },
                     [&](const auto&){}
                 },


### PR DESCRIPTION
BaK uses a weird hack of ShowDialog(-1) in the script actions for static scenes to indicate "render the actor at center of screen". Respecting this fixes the Krondor palace, Northwarden, Cullich, and more GDS scenes.