### PR TITLE
Issue #78 - Correct semantics of TTM frames

### DIFF
--- a/app/display_script.cpp
+++ b/app/display_script.cpp
@@ -33,9 +33,10 @@ int main(int argc, char** argv)
     }
     else if (mode == "dynamic")
     {
-        for (const auto& action : BAK::LoadDynamicScripts(fb))
+        unsigned index = 0;
+        for (const auto& frame : BAK::LoadDynamicScripts(fb))
         {
-            std::cout << action << "\n";
+            std::cout << index++ << " " << frame;
         }
     }
     else if (mode == "rawads")

--- a/app/play_ttm.cpp
+++ b/app/play_ttm.cpp
@@ -109,7 +109,7 @@ int main(int argc, char** argv)
         {
             rootWidget.OnMouseEvent(
                 Gui::LeftMousePress{guiScaleInv * click});
-            dynamicTTM.AdvanceAction();
+            dynamicTTM.AdvanceFrame();
         },
         [&](const auto click)
         {

--- a/bak/scene/scene.cpp
+++ b/bak/scene/scene.cpp
@@ -76,7 +76,20 @@ std::ostream& operator<<(std::ostream& os, const Script& scene)
 
 namespace {
 
-std::vector<ScriptAction> DecodeTTM(FileBuffer& fb, Tags& tags)
+std::optional<unsigned> FrameTag(const std::vector<ScriptAction>& actions)
+{
+    if (actions.empty())
+    {
+        return std::nullopt;
+    }
+
+    std::optional<unsigned> tag{};
+    evaluate_if<SetScript>(actions.front(), [&](const auto& a){ tag = a.mScriptNumber; });
+    evaluate_if<ScriptTag>(actions.front(), [&](const auto& a){ tag = a.mScriptNumber; });
+    return tag;
+}
+
+std::vector<ScriptFrame> DecodeTTM(FileBuffer& fb, Tags& tags)
 {
     const auto& logger = Logging::LogState::GetLogger(__FUNCTION__);
 
@@ -96,7 +109,14 @@ std::vector<ScriptAction> DecodeTTM(FileBuffer& fb, Tags& tags)
 
     const auto offset = 8 * 3 + pageBuffer.GetSize() + versionBuffer.GetSize() + 5;
 
+    std::vector<ScriptFrame> frames{};
     std::vector<ScriptAction> actions{};
+
+    const auto PushFrame = [&]{
+        const auto tag = FrameTag(actions);
+        frames.emplace_back(ScriptFrame{std::move(actions), tag});
+        actions.clear();
+    };
 
     unsigned activeEdgeColor = 0xf;
     unsigned activeFillColor = 0xf;
@@ -180,7 +200,7 @@ std::vector<ScriptAction> DecodeTTM(FileBuffer& fb, Tags& tags)
             case Actions::SLOT_PALETTE:
                 actions.emplace_back(SlotPalette{static_cast<unsigned>(args[0])});
                 break;
-            case Actions::SET_SCRIPTA: [[fallthrough]];
+            case Actions::SCRIPT_TAG: [[fallthrough]];
             case Actions::SET_SCRIPT:
             {
                 ASSERT(!args.empty());
@@ -188,10 +208,15 @@ std::vector<ScriptAction> DecodeTTM(FileBuffer& fb, Tags& tags)
                 const auto sceneTag = tag
                     ? *tag
                     : std::to_string(static_cast<int>(args[0]));
-                actions.emplace_back(
-                    SetScript{
-                        sceneTag,
-                        static_cast<std::uint16_t>(args[0])});
+                const auto scriptNumber = static_cast<std::uint16_t>(args[0]);
+                if (action == Actions::SCRIPT_TAG)
+                {
+                    actions.emplace_back(ScriptTag{sceneTag, scriptNumber});
+                }
+                else
+                {
+                    actions.emplace_back(SetScript{sceneTag, scriptNumber});
+                }
             } break;
             case Actions::SET_CLIP_REGION:
                 actions.emplace_back(
@@ -288,11 +313,11 @@ std::vector<ScriptAction> DecodeTTM(FileBuffer& fb, Tags& tags)
             case Actions::DRAW_SAVED_REGION:
                 actions.emplace_back(DrawSavedRegion{static_cast<unsigned>(args[0])});
                 break;
-            case Actions::UPDATE:
-                actions.emplace_back(Update{});
+            case Actions::END_FRAME:
+                PushFrame();
                 break;
-            case Actions::PURGE:
-                actions.emplace_back(Purge{});
+            case Actions::END_SCRIPT:
+                actions.emplace_back(EndScript{});
                 break;
             case Actions::DELAY:
                 actions.emplace_back(Delay{static_cast<unsigned>(args[0])});
@@ -306,7 +331,14 @@ std::vector<ScriptAction> DecodeTTM(FileBuffer& fb, Tags& tags)
         logger.Debug() << ss.str() << "\n";
     }
 
-    return actions;
+    if (!actions.empty())
+    {
+        PushFrame();
+    }
+
+    ASSERT(frames.size() == pages);
+
+    return frames;
 }
 
 }
@@ -314,7 +346,7 @@ std::vector<ScriptAction> DecodeTTM(FileBuffer& fb, Tags& tags)
 std::unordered_map<unsigned, Script> LoadScripts(FileBuffer& fb)
 {
     Tags tags{};
-    const auto actions = DecodeTTM(fb, tags);
+    const auto frames = DecodeTTM(fb, tags);
 
     std::unordered_map<unsigned, Script> scripts{};
 
@@ -360,99 +392,98 @@ std::unordered_map<unsigned, Script> LoadScripts(FileBuffer& fb)
         }
     };
 
-    for (const auto& action : actions)
+    for (const auto& frame : frames)
     {
-        std::visit(
-            overloaded{
-                [&](const SetScript& setScript)
-                {
-                    if (loadingScene)
-                        PushScript();
+        for (const auto& action : frame.mActions)
+        {
+            std::visit(
+                overloaded{
+                    [&](const SetScript& setScript)
+                    {
+                        if (loadingScene)
+                            PushScript();
 
-                    currentScript.mSceneTag = setScript.mName;
-                    currentScript.mActions.clear();
-                    currentScript.mImages.clear();
-                    currentScript.mScreens.clear();
-                    currentScript.mPalettes.clear();
-                    images.clear();
-                    imageSlots.clear();
-                    palettes.clear();
-                    imageSlot.reset();
-                    screens.clear();
-                    loadingScene = true;
-                },
-                [&](const SlotImage& slotImage)
-                {
-                    imageSlot = slotImage.mSlot;
-                },
-                [&](const SlotPalette& slotPalette)
-                {
-                    paletteSlot = slotPalette.mSlot;
-                },
-                [&](const LoadPalette& loadPalette)
-                {
-                    //ASSERT(loadingScene);
-                    ASSERT(paletteSlot);
-                    palettes[*paletteSlot] = loadPalette.mPalette;
-                    if (!imageSlots.contains(*paletteSlot))
+                        currentScript.mSceneTag = setScript.mName;
+                        currentScript.mActions.clear();
+                        currentScript.mImages.clear();
+                        currentScript.mScreens.clear();
+                        currentScript.mPalettes.clear();
+                        images.clear();
+                        imageSlots.clear();
+                        palettes.clear();
+                        imageSlot.reset();
+                        screens.clear();
+                        loadingScene = true;
+                    },
+                    [&](const SlotImage& slotImage)
                     {
-                        imageSlots[*paletteSlot] = ImageSlot{};
-                    }
-                    imageSlots[*paletteSlot].mPalette = *paletteSlot;
-                },
-                [&](const LoadImage& loadImage)
-                {
-                    //ASSERT(loadingScene);
-                    ASSERT(imageSlot);
-                    images[*imageSlot] = std::make_pair(
-                        loadImage.mImage,
-                        paletteSlot ? *paletteSlot : *imageSlot);
-                    if (!imageSlots.contains(*imageSlot))
+                        imageSlot = slotImage.mSlot;
+                    },
+                    [&](const SlotPalette& slotPalette)
                     {
-                        imageSlots[*imageSlot] = ImageSlot{};
-                    }
-                },
-                [&](const LoadScreen& loadScreen)
-                {
-                    if (!paletteSlot) return;
-                    screens[*paletteSlot] = std::make_pair(
-                        loadScreen.mScreenName,
-                        *paletteSlot);
-                },
-                [&](const ClipRegion& a)
-                {
-                    currentScript.mActions.emplace_back(a);
-                },
-                [&](const CopyLayer& a)
-                {
-                    currentScript.mActions.emplace_back(a);
-                },
-                [&](const DrawRect& a)
-                {
-                    currentScript.mActions.emplace_back(a);
-                },
-                [&](const DrawSprite& a)
-                {
-                    currentScript.mActions.emplace_back(a);
-                },
-                [&](const ShowDialog& a)
-                {
-                    currentScript.mActions.emplace_back(a);
-                },
-                [&](const Update& a)
-                {
-                    currentScript.mActions.emplace_back(a);
-                },
-                [&](const Purge& a)
-                {
-                    currentScript.mActions.emplace_back(a);
-                },
-                [&](const Delay& a)
-                {
-                    currentScript.mActions.emplace_back(a);
-                },
-                [](const auto&){}},
-            action);
+                        paletteSlot = slotPalette.mSlot;
+                    },
+                    [&](const LoadPalette& loadPalette)
+                    {
+                        //ASSERT(loadingScene);
+                        ASSERT(paletteSlot);
+                        palettes[*paletteSlot] = loadPalette.mPalette;
+                        if (!imageSlots.contains(*paletteSlot))
+                        {
+                            imageSlots[*paletteSlot] = ImageSlot{};
+                        }
+                        imageSlots[*paletteSlot].mPalette = *paletteSlot;
+                    },
+                    [&](const LoadImage& loadImage)
+                    {
+                        //ASSERT(loadingScene);
+                        ASSERT(imageSlot);
+                        images[*imageSlot] = std::make_pair(
+                            loadImage.mImage,
+                            paletteSlot ? *paletteSlot : *imageSlot);
+                        if (!imageSlots.contains(*imageSlot))
+                        {
+                            imageSlots[*imageSlot] = ImageSlot{};
+                        }
+                    },
+                    [&](const LoadScreen& loadScreen)
+                    {
+                        if (!paletteSlot) return;
+                        screens[*paletteSlot] = std::make_pair(
+                            loadScreen.mScreenName,
+                            *paletteSlot);
+                    },
+                    [&](const ClipRegion& a)
+                    {
+                        currentScript.mActions.emplace_back(a);
+                    },
+                    [&](const CopyLayer& a)
+                    {
+                        currentScript.mActions.emplace_back(a);
+                    },
+                    [&](const DrawRect& a)
+                    {
+                        currentScript.mActions.emplace_back(a);
+                    },
+                    [&](const DrawSprite& a)
+                    {
+                        currentScript.mActions.emplace_back(a);
+                    },
+                    [&](const ShowDialog& a)
+                    {
+                        currentScript.mActions.emplace_back(a);
+                    },
+                    [&](const EndScript& a)
+                    {
+                        currentScript.mActions.emplace_back(a);
+                    },
+                    [&](const Delay& a)
+                    {
+                        currentScript.mActions.emplace_back(a);
+                    },
+                    [](const auto&){}},
+                action);
+        }
     }
 
     // Push final scene
@@ -461,7 +492,7 @@ std::unordered_map<unsigned, Script> LoadScripts(FileBuffer& fb)
     return scripts;
 }
 
-std::vector<ScriptAction> LoadDynamicScripts(FileBuffer& fb)
+std::vector<ScriptFrame> LoadDynamicScripts(FileBuffer& fb)
 {
     Tags tags{};
     return DecodeTTM(fb, tags);

--- a/bak/scene/scene.hpp
+++ b/bak/scene/scene.hpp
@@ -33,7 +33,7 @@ struct Script
 std::ostream& operator<<(std::ostream&, const Script&);
 
 std::unordered_map<unsigned, Script> LoadScripts(FileBuffer& fb);
-std::vector<ScriptAction> LoadDynamicScripts(FileBuffer& fb);
+std::vector<ScriptFrame> LoadDynamicScripts(FileBuffer& fb);
 
 FileBuffer DecompressSCR(FileBuffer& fb);
 FileBuffer DecompressTT3(FileBuffer& fb);

--- a/bak/scene/sceneData.cpp
+++ b/bak/scene/sceneData.cpp
@@ -48,8 +48,8 @@ std::string_view ToString(Actions a)
     case Actions::SAVE_BACKGROUND: return "SaveBackground";
     case Actions::DRAW_BACKGROUND: return "DrawBackground";
     case Actions::DRAW_BACKGROUND_B: return "DRAW_BACKGROUND_B";
-    case Actions::PURGE: return "Purge";
-    case Actions::UPDATE: return "Update";
+    case Actions::END_SCRIPT: return "EndScript";
+    case Actions::END_FRAME: return "EndFrame";
     case Actions::DO_SOMETHING_A: return "DOSOMETHINGA";
     case Actions::DISABLE_CLEAR: return "DisableClear";
     case Actions::ENABLE_CLEAR: return "EnableClear";
@@ -58,7 +58,7 @@ std::string_view ToString(Actions a)
     case Actions::SLOT_PALETTE: return "SlotPalette";
     case Actions::SLOT_FONT: return "SlotFont";
     case Actions::SET_SCRIPT: return "SetScript";
-    case Actions::SET_SCRIPTA: return "SETSCRIPTA";
+    case Actions::SCRIPT_TAG: return "ScriptTag";
     case Actions::SET_SAVE_LAYER: return "SetSaveLayer";
     case Actions::GOTO_TAG: return "GotoTag";
     case Actions::SET_COLOR: return "SetColors";
@@ -116,6 +116,12 @@ std::ostream& operator<<(std::ostream& os, const SetScript& ss)
     return os;
 }
 
+std::ostream& operator<<(std::ostream& os, const ScriptTag& sl)
+{
+    os << "ScriptTag {" << sl.mScriptNumber << " " << sl.mName << "}";
+    return os;
+}
+
 std::ostream& operator<<(std::ostream& os, const LoadScreen& ls)
 {
     os << "LoadScreen {" << ls.mScreenName << "}";
@@ -166,12 +172,7 @@ std::ostream& operator<<(std::ostream& os, const DisableClipRegion& a)
 
 std::ostream& operator<<(std::ostream& os, const Delay& a)
 {
-    return os << "Delay { time: " << a.mDelayMs << "}";
-}
-
-std::ostream& operator<<(std::ostream& os, const Update& a)
-{
-    return os << "Update{}";
+    return os << "Delay { ticks: " << a.mTicks << "}";
 }
 
 std::ostream& operator<<(std::ostream& os, const SaveBackground& a)
@@ -194,9 +195,9 @@ std::ostream& operator<<(std::ostream& os, const FadeOut& a)
     return os << "FadeOut{}";
 }
 
-std::ostream& operator<<(std::ostream& os, const Purge& a)
+std::ostream& operator<<(std::ostream& os, const EndScript& a)
 {
-    return os << "Purge{}";
+    return os << "EndScript{}";
 }
 
 std::ostream& operator<<(std::ostream& os, const SaveRectToBackground& a)
@@ -267,6 +268,21 @@ std::ostream& operator<<(std::ostream& os, const ScriptAction& sa)
         [&](const auto& x){ os << x; }},
         sa);
 
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const ScriptFrame& sf)
+{
+    os << "Frame";
+    if (sf.mTag)
+    {
+        os << " [tag " << *sf.mTag << "]";
+    }
+    os << "\n";
+    for (const auto& action : sf.mActions)
+    {
+        os << "\t" << action << "\n";
+    }
     return os;
 }
 

--- a/bak/scene/sceneData.hpp
+++ b/bak/scene/sceneData.hpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include <ostream>
 #include <variant>
@@ -39,21 +40,19 @@ enum class Actions
     UNKNOWN_A           = 0x0070,
     DRAW_BACKGROUND     = 0x0080,
     DRAW_BACKGROUND_B   = 0x00c0,
-    PURGE               = 0x0110,
-    // Purge means jump out of this scene
-    // if no purge, then we continue looping through the
-    // actions. This is how C12 archer works...
-    UPDATE              = 0x0ff0,
+    END_SCRIPT          = 0x0110,
+    // Ends the frame
+    END_FRAME           = 0x0ff0,
     DO_SOMETHING_A      = 0x0400,
-    // Don't clear sprites between updates...
+    // Don't clear sprites between frames...
     DISABLE_CLEAR       = 0x0500,
     ENABLE_CLEAR        = 0x0510,
     DELAY               = 0x1020,
     SLOT_IMAGE          = 0x1050,
     SLOT_PALETTE        = 0x1060,
     SLOT_FONT           = 0x1070,
-    SET_SCRIPTA         = 0x1100, // Local taG?
-    SET_SCRIPT          = 0x1110, // TAG??
+    SCRIPT_TAG          = 0x1100,
+    SET_SCRIPT          = 0x1110,
     SET_SAVE_LAYER      = 0x1120,
     GOTO_TAG            = 0x1200,
     SET_COLOR           = 0x2000,
@@ -103,6 +102,14 @@ struct SetScript
 };
 
 std::ostream& operator<<(std::ostream&, const SetScript&);
+
+struct ScriptTag
+{
+    std::string mName;
+    std::uint16_t mScriptNumber;
+};
+
+std::ostream& operator<<(std::ostream&, const ScriptTag&);
 
 struct LoadScreen
 { 
@@ -192,7 +199,7 @@ struct SaveRegionToLayer
     glm::ivec2 dims;
 };
 
-struct Purge
+struct EndScript
 {
 };
 
@@ -207,13 +214,8 @@ struct SetWindow
 
 struct Delay
 {
-    unsigned mDelayMs; // units??
+    unsigned mTicks;
 };
-
-struct Update
-{
-};
-
 
 struct SetColors
 {
@@ -274,16 +276,16 @@ using ScriptAction = std::variant<
     DrawRect,
     CopyLayer,
     DrawSprite,
-    Purge,
+    EndScript,
     SaveBackground,
     SaveRectToBackground,
-    Update,
     LoadImage,
     LoadPalette,
     FadeOut,
     FadeIn,
     LoadScreen,
     SetScript,
+    ScriptTag,
     SetColors,
     SlotImage,
     SetSaveLayer,
@@ -295,5 +297,13 @@ using ScriptAction = std::variant<
     SlotPalette>;
 
 std::ostream& operator<<(std::ostream& os, const ScriptAction& sa);
+
+struct ScriptFrame
+{
+    std::vector<ScriptAction> mActions;
+    std::optional<unsigned> mTag;
+};
+
+std::ostream& operator<<(std::ostream& os, const ScriptFrame& sf);
 
 }

--- a/bak/scene/ttmRenderer.cpp
+++ b/bak/scene/ttmRenderer.cpp
@@ -23,141 +23,138 @@ TTMRenderer::TTMRenderer(
 
 Graphics::TextureStore TTMRenderer::RenderTTM()
 {
-    while (!AdvanceAction()) {}
+    while (AdvanceFrame()) {}
     return mRenderedFrames;
 }
 
-bool TTMRenderer::AdvanceAction()
+bool TTMRenderer::AdvanceFrame()
 {
-    mLogger.Debug() << "AdvanceAction" << "\n";
-    auto actionOpt = mRunner.GetNextAction();
-    if (!actionOpt)
+    auto frameOpt = mRunner.GetNextFrame();
+    if (!frameOpt)
     {
-        return true;
+        return false;
     }
-    auto action = *actionOpt;
-    mLogger.Debug() << "Handle action: " << action << std::endl;
-    std::visit(
-        overloaded{
-            [&](const SlotPalette& sp){
-                mCurrentPaletteSlot = sp.mSlot;
-            },
-            [&](const LoadPalette& p){
-                mPaletteSlots.erase(mCurrentPaletteSlot);
-                mPaletteSlots.emplace(mCurrentPaletteSlot, Palette{p.mPalette});
-            },
-            [&](const SlotImage& sp){
-                mCurrentImageSlot = sp.mSlot;
-            },
-            [&](const LoadImage& p){
-                auto fb = FileBufferFactory::Get().CreateDataBuffer(p.mImage);
-                mImageSlots.erase(mCurrentImageSlot);
-                mImageSlots.emplace(mCurrentImageSlot, LoadImages(fb));
-                mLogger.Debug() << "Loaded image: " << p.mImage << " to slot: " << mCurrentImageSlot
-                    << " has " << mImageSlots.at(mCurrentImageSlot).mImages.size() << " images\n";
-            },
-            [&](const LoadScreen& p){
-                if (!mPaletteSlots.contains(mCurrentPaletteSlot))
-                {
-                    mLogger.Debug() << "No palette in slot " << mCurrentPaletteSlot
-                        << ", skipping screen " << p.mScreenName << "\n";
-                    return;
-                }
-                auto fb = FileBufferFactory::Get().CreateDataBuffer(p.mScreenName);
-                mRenderer.CopyImage(
-                    LoadScreenResource(fb),
-                    mPaletteSlots.at(mCurrentPaletteSlot).mPaletteData,
-                    glm::ivec2{0, 0},
-                    mRenderer.GetLayer(Layer::Screen));
-                mRenderer.CopyRect(
-                    glm::ivec2{0, 0},
-                    glm::ivec2{320, 200},
-                    Layer::Screen,
-                    Layer::Background);
-            },
-            [&](const CopyLayer& sa){
-                mRenderer.CopyRect(
-                    sa.mPosition,
-                    sa.mDimensions,
-                    LayerFromArgument(sa.mSourceLayer),
-                    LayerFromArgument(sa.mTargetLayer));
-            },
-            [&](const DrawSprite& sa){
-                assert(mImageSlots.contains(sa.mImageSlot));
-                assert(static_cast<unsigned>(sa.mSpriteIndex)
-                        < mImageSlots.at(sa.mImageSlot).mImages.size());
 
-                mRenderer.RenderSprite(
-                    mImageSlots.at(sa.mImageSlot).mImages[sa.mSpriteIndex],
-                    mPaletteSlots.at(mCurrentPaletteSlot).mPaletteData,
-                    glm::ivec2{sa.mX, sa.mY},
-                    sa.mFlipX,
-                    sa.mFlipY,
-                    mRenderer.GetLayer(Layer::Screen));
-            },
-            [&](const Update& sr){
-                RenderFrame();
-            },
-            [&](const SaveRectToBackground& si){
-                mRenderer.CopyRect(si.pos, si.dims, Layer::Screen, Layer::Background);
-            },
-            [&](const SetSaveLayer& ssl){
-                mImageSaveLayer = ssl.mLayer;
-            },
-            [&](const SaveRegionToLayer& si){
-                mClearRegions.insert_or_assign(mImageSaveLayer, si);
-                mSaves.insert_or_assign(
-                    mImageSaveLayer,
-                    mRenderer.ExtractRegion(si.pos, si.dims, Layer::Screen));
-            },
-            [&](const DrawSavedRegion& si){
-                mRenderer.CopyRect(
-                    mSaves.at(si.mLayer),
-                    mClearRegions.at(si.mLayer).pos,
-                    mRenderer.GetLayer(Layer::Screen));
-            },
-            [&](const SaveBackground&){
-                mRenderer.CopyRect(
-                    glm::ivec2{0, 0},
-                    glm::ivec2{320, 200},
-                    Layer::Screen,
-                    Layer::Background);
-            },
-            [&](const DrawRect& sr){
-                if (!mPaletteSlots.contains(mCurrentPaletteSlot))
-                {
-                    // what to do in this scenario..?
-                    return;
-                }
-                mRenderer.DrawRect(
-                    sr.mPos, sr.mDims,
-                    mPaletteSlots.at(mCurrentPaletteSlot).mPaletteData,
-                    sr.mFilled,
-                    mRenderer.GetLayer(Layer::Screen));
-            },
-            [&](const ClipRegion& a){
-                mRenderer.SetClipRegion(a);
-            },
-            [&](const DisableClipRegion&){
-                mRenderer.ClearClipRegion();
-            },
-            [&](const SetColors& sc){
-                mRenderer.SetColors(sc.mForegroundColor, sc.mBackgroundColor);
-            },
-            [&](const Purge&){
-                assert(false);
-            },
-            [&](const GotoTag& sa){
-                assert(false);
-            },
-            [&](const auto& a){
-                Logging::LogInfo(__FUNCTION__) << "Unhandled action: " << a << "\n";
-            }
-        },
-        action
-    );
+    for (const auto& action : frameOpt->mActions)
+    {
+        mLogger.Debug() << "Handle action: " << action << std::endl;
+        std::visit(
+            overloaded{
+                [&](const SlotPalette& sp){
+                    mCurrentPaletteSlot = sp.mSlot;
+                },
+                [&](const LoadPalette& p){
+                    mPaletteSlots.erase(mCurrentPaletteSlot);
+                    mPaletteSlots.emplace(mCurrentPaletteSlot, Palette{p.mPalette});
+                },
+                [&](const SlotImage& sp){
+                    mCurrentImageSlot = sp.mSlot;
+                },
+                [&](const LoadImage& p){
+                    auto fb = FileBufferFactory::Get().CreateDataBuffer(p.mImage);
+                    mImageSlots.erase(mCurrentImageSlot);
+                    mImageSlots.emplace(mCurrentImageSlot, LoadImages(fb));
+                    mLogger.Debug() << "Loaded image: " << p.mImage << " to slot: " << mCurrentImageSlot
+                        << " has " << mImageSlots.at(mCurrentImageSlot).mImages.size() << " images\n";
+                },
+                [&](const LoadScreen& p){
+                    if (!mPaletteSlots.contains(mCurrentPaletteSlot))
+                    {
+                        mLogger.Debug() << "No palette in slot " << mCurrentPaletteSlot
+                            << ", skipping screen " << p.mScreenName << "\n";
+                        return;
+                    }
+                    auto fb = FileBufferFactory::Get().CreateDataBuffer(p.mScreenName);
+                    mRenderer.CopyImage(
+                        LoadScreenResource(fb),
+                        mPaletteSlots.at(mCurrentPaletteSlot).mPaletteData,
+                        glm::ivec2{0, 0},
+                        mRenderer.GetLayer(Layer::Screen));
+                    mRenderer.CopyRect(
+                        glm::ivec2{0, 0},
+                        glm::ivec2{320, 200},
+                        Layer::Screen,
+                        Layer::Background);
+                },
+                [&](const CopyLayer& sa){
+                    mRenderer.CopyRect(
+                        sa.mPosition,
+                        sa.mDimensions,
+                        LayerFromArgument(sa.mSourceLayer),
+                        LayerFromArgument(sa.mTargetLayer));
+                },
+                [&](const DrawSprite& sa){
+                    assert(mImageSlots.contains(sa.mImageSlot));
+                    assert(static_cast<unsigned>(sa.mSpriteIndex)
+                            < mImageSlots.at(sa.mImageSlot).mImages.size());
 
-    return false;
+                    mRenderer.RenderSprite(
+                        mImageSlots.at(sa.mImageSlot).mImages[sa.mSpriteIndex],
+                        mPaletteSlots.at(mCurrentPaletteSlot).mPaletteData,
+                        glm::ivec2{sa.mX, sa.mY},
+                        sa.mFlipX,
+                        sa.mFlipY,
+                        mRenderer.GetLayer(Layer::Screen));
+                },
+                [&](const SaveRectToBackground& si){
+                    mRenderer.CopyRect(si.pos, si.dims, Layer::Screen, Layer::Background);
+                },
+                [&](const SetSaveLayer& ssl){
+                    mImageSaveLayer = ssl.mLayer;
+                },
+                [&](const SaveRegionToLayer& si){
+                    mClearRegions.insert_or_assign(mImageSaveLayer, si);
+                    mSaves.insert_or_assign(
+                        mImageSaveLayer,
+                        mRenderer.ExtractRegion(si.pos, si.dims, Layer::Screen));
+                },
+                [&](const DrawSavedRegion& si){
+                    mRenderer.CopyRect(
+                        mSaves.at(si.mLayer),
+                        mClearRegions.at(si.mLayer).pos,
+                        mRenderer.GetLayer(Layer::Screen));
+                },
+                [&](const SaveBackground&){
+                    mRenderer.CopyRect(
+                        glm::ivec2{0, 0},
+                        glm::ivec2{320, 200},
+                        Layer::Screen,
+                        Layer::Background);
+                },
+                [&](const DrawRect& sr){
+                    if (!mPaletteSlots.contains(mCurrentPaletteSlot))
+                    {
+                        // what to do in this scenario..?
+                        return;
+                    }
+                    mRenderer.DrawRect(
+                        sr.mPos, sr.mDims,
+                        mPaletteSlots.at(mCurrentPaletteSlot).mPaletteData,
+                        sr.mFilled,
+                        mRenderer.GetLayer(Layer::Screen));
+                },
+                [&](const ClipRegion& a){
+                    mRenderer.SetClipRegion(a);
+                },
+                [&](const DisableClipRegion&){
+                    mRenderer.ClearClipRegion();
+                },
+                [&](const SetColors& sc){
+                    mRenderer.SetColors(sc.mForegroundColor, sc.mBackgroundColor);
+                },
+                [&](const EndScript&){},
+                [&](const GotoTag&){},
+                [&](const auto& a){
+                    Logging::LogInfo(__FUNCTION__) << "Unhandled action: " << a << "\n";
+                }
+            },
+            action
+        );
+    }
+
+    RenderFrame();
+
+    return true;
 }
 void TTMRenderer::RenderFrame()
 {

--- a/bak/scene/ttmRenderer.hpp
+++ b/bak/scene/ttmRenderer.hpp
@@ -25,7 +25,7 @@ public:
     Graphics::TextureStore RenderTTM();
 
 private:
-    bool AdvanceAction();
+    bool AdvanceFrame();
 
     void RenderFrame();
 

--- a/bak/scene/ttmRunner.cpp
+++ b/bak/scene/ttmRunner.cpp
@@ -23,87 +23,93 @@ void TTMRunner::LoadTTM(
     auto adsFb = FileBufferFactory::Get().CreateDataBuffer(adsFile);
     mAds = ADS::LoadAds(adsFb);
     auto ttmFb = FileBufferFactory::Get().CreateDataBuffer(ttmFile);
-    mActions = LoadDynamicScripts(ttmFb);
+    mFrames = LoadDynamicScripts(ttmFb);
 
     mStarted.clear();
     mFinished.clear();
     mPendingScripts.clear();
     mCurrentScript = 0;
-    mCurrentAction = 0;
+    mCurrentFrame.reset();
 
+    EvaluateScene();
     StartNextScript();
 }
 
-std::optional<ScriptAction> TTMRunner::GetNextAction()
+std::optional<ScriptFrame> TTMRunner::GetNextFrame()
 {
-    if (mCurrentAction == mActions.size())
+    while (mCurrentFrame)
     {
-        return std::nullopt;
-    }
-
-    auto action = mActions[mCurrentAction];
-    bool nextActionChosen = false;
-    bool finishEarly = false;
-
-    std::visit(
-        overloaded{
-            [&](const Purge&){
-                StopScript(mCurrentScript);
-                StartNextScript();
-                nextActionChosen = true;
-            },
-            [&](const GotoTag& sa){
-                // Hack til I figure out exactly how C31 works...
-                if (sa.mTag == 4)
-                {
-                    finishEarly = true;
-                    return;
-                }
-                mCurrentAction = FindActionMatchingTag(sa.mTag);
-                nextActionChosen = true;
-            },
-            [&](const auto&){}
-        },
-        action
-    );
-
-    if (finishEarly)
-    {
-        return std::nullopt;
-    }
-
-    if (nextActionChosen)
-    {
-        if (mCurrentAction == mActions.size())
+        if (*mCurrentFrame >= mFrames.size())
         {
-            return std::nullopt;
+            FinishCurrentScript();
+            continue;
         }
 
-        action = mActions[mCurrentAction];
+        const auto frame = mFrames[*mCurrentFrame];
+
+        bool endScript = false;
+        std::optional<unsigned> gotoTag{};
+        for (const auto& action : frame.mActions)
+        {
+            std::visit(
+                overloaded{
+                    [&](const EndScript&){ endScript = true; },
+                    [&](const GotoTag& sa){ gotoTag = sa.mTag; },
+                    [&](const auto&){}
+                },
+                action
+            );
+        }
+
+        if (endScript)
+        {
+            FinishCurrentScript();
+        }
+        else if (gotoTag)
+        {
+            mCurrentFrame = FindFrameMatchingTag(*gotoTag);
+            if (!mCurrentFrame)
+            {
+                mLogger.Debug() << "No frame tagged: " << *gotoTag << "\n";
+                FinishCurrentScript();
+            }
+        }
+        else
+        {
+            mCurrentFrame = *mCurrentFrame + 1;
+        }
+
+        return frame;
     }
 
-    mCurrentAction++;
+    return std::nullopt;
+}
 
-    return action;
+void TTMRunner::FinishCurrentScript()
+{
+    mLogger.Debug() << "Finished script: " << mCurrentScript << "\n";
+    mFinished.insert(mCurrentScript);
+    EvaluateScene();
+    StartNextScript();
 }
 
 void TTMRunner::StartNextScript()
 {
-    if (mPendingScripts.empty())
+    while (!mPendingScripts.empty())
     {
-        EvaluateScene();
+        mCurrentScript = mPendingScripts.front();
+        mPendingScripts.pop_front();
+        mCurrentFrame = FindFrameMatchingTag(mCurrentScript);
+        if (mCurrentFrame)
+        {
+            mLogger.Debug() << "Starting script: " << mCurrentScript << "\n";
+            return;
+        }
+
+        mLogger.Debug() << "No frame tagged: " << mCurrentScript << "\n";
     }
 
-    if (mPendingScripts.empty())
-    {
-        mCurrentAction = mActions.size();
-        return;
-    }
-
-    mCurrentScript = mPendingScripts.front();
-    mPendingScripts.pop_front();
-    mLogger.Debug() << "Starting script: " << mCurrentScript << "\n";
-    mCurrentAction = FindActionMatchingTag(mCurrentScript);
+    mCurrentFrame.reset();
 }
 
 bool TTMRunner::EvaluateScene()
@@ -175,30 +181,20 @@ void TTMRunner::StartScript(unsigned scriptTag)
 
 void TTMRunner::StopScript(unsigned scriptTag)
 {
-    if (scriptTag == mCurrentScript)
-    {
-        mFinished.insert(scriptTag);
-    }
+    std::erase(mPendingScripts, scriptTag);
 }
 
-unsigned TTMRunner::FindActionMatchingTag(unsigned tag) const
+std::optional<unsigned> TTMRunner::FindFrameMatchingTag(unsigned tag) const
 {
-    std::optional<unsigned> foundIndex{};
-    for (unsigned i = 0; i < mActions.size(); i++)
+    for (unsigned i = 0; i < mFrames.size(); i++)
     {
-        evaluate_if<SetScript>(mActions[i], [&](const auto& action) {
-            if (action.mScriptNumber == tag)
-            {
-                foundIndex = i;
-            }
-        });
-        if (foundIndex)
+        if (mFrames[i].mTag == tag)
         {
-            return *foundIndex;
+            return i;
         }
     }
 
-    return 0;
+    return std::nullopt;
 }
 
 }

--- a/bak/scene/ttmRunner.hpp
+++ b/bak/scene/ttmRunner.hpp
@@ -22,26 +22,27 @@ public:
         std::string adsFile,
         std::string ttmFile);
 
-    std::optional<ScriptAction> GetNextAction();
+    std::optional<ScriptFrame> GetNextFrame();
 
 private:
+    void FinishCurrentScript();
     void StartNextScript();
     bool EvaluateScene();
     void ExecuteBlock(const ADS::ActionBlock& block);
     bool EvaluateCondition(const ADS::Condition& condition) const;
     void StartScript(unsigned scriptTag);
     void StopScript(unsigned scriptTag);
-    unsigned FindActionMatchingTag(unsigned tag) const;
+    std::optional<unsigned> FindFrameMatchingTag(unsigned tag) const;
 
     ADS::Ads mAds;
-    std::vector<ScriptAction> mActions;
+    std::vector<ScriptFrame> mFrames;
 
     std::unordered_set<unsigned> mStarted;
     std::unordered_set<unsigned> mFinished;
     std::deque<unsigned> mPendingScripts;
     unsigned mCurrentScript = 0;
 
-    unsigned mCurrentAction = 0;
+    std::optional<unsigned> mCurrentFrame;
 
     const Logging::Logger& mLogger;
 };

--- a/gui/cutscenePlayer.cpp
+++ b/gui/cutscenePlayer.cpp
@@ -60,7 +60,7 @@ void CutscenePlayer::Play()
             ClearChildren();
             AddChildBack(mDynamicTTM.GetScene());
             mTtmPlaying = true;
-            mDynamicTTM.AdvanceAction();
+            mDynamicTTM.AdvanceFrame();
         },
         [&](const BAK::BookChapter& book)
         {
@@ -89,7 +89,7 @@ void CutscenePlayer::Advance()
 {
     if (GetChildren()[0] == mDynamicTTM.GetScene())
     {
-        mDynamicTTM.AdvanceAction();
+        mDynamicTTM.AdvanceFrame();
     }
     else if (GetChildren()[0] == mBookPlayer.GetBackground())
     {
@@ -104,7 +104,7 @@ void CutscenePlayer::BookFinished()
         mGuiManager.DoFade(1.5, [&]{
             ClearChildren();
             AddChildBack(mDynamicTTM.GetScene());
-            mDynamicTTM.AdvanceAction();
+            mDynamicTTM.AdvanceFrame();
         });
     }
     else

--- a/gui/dynamicTTM.cpp
+++ b/gui/dynamicTTM.cpp
@@ -123,71 +123,86 @@ void DynamicTTM::BeginScene(
 
     mDelaying = false;
     mDelay = 0;
+    mCurrentFrame.reset();
+    mNextAction = 0;
     mRunner.LoadTTM(adsFile, ttmFile);
 
     ClearText();
 }
 
-bool DynamicTTM::AdvanceAction()
+bool DynamicTTM::AdvanceFrame()
 {
     if (mDelaying) return false;
 
-    auto actionOpt = mRunner.GetNextAction();
-    if (!actionOpt)
+    if (!mCurrentFrame)
     {
-        mSceneFinished();
-        if (mMusicTracksPlayed > 0)
+        auto frameOpt = mRunner.GetNextFrame();
+        if (!frameOpt)
         {
-            AudioA::GetAudioManager().PopTrack();
+            mSceneFinished();
+            if (mMusicTracksPlayed > 0)
+            {
+                AudioA::GetAudioManager().PopTrack();
+            }
+            return true;
         }
-        return true;
+
+        mCurrentFrame = *frameOpt;
+        mNextAction = 0;
+
+        if (mCurrentRenderedFrame < mRenderedFrames.GetTextures().size())
+        {
+            mSceneElements.back().SetTexture(
+                Graphics::TextureIndex{mCurrentRenderedFrame++});
+        }
     }
 
-    auto action = *actionOpt;
-    mLogger.Debug() << "This action: " << action << "\n";
-
     bool waitForClick = false;
-    std::visit(
-        overloaded{
-            [&](const BAK::Delay& delay){
-                mDelay = static_cast<double>(delay.mDelayMs) / 1000.;
+    while (mNextAction < mCurrentFrame->mActions.size())
+    {
+        const auto& action = mCurrentFrame->mActions[mNextAction++];
+        mLogger.Debug() << "This action: " << action << "\n";
+        std::visit(
+            overloaded{
+                [&](const BAK::Delay& delay){
+                    mDelay = static_cast<double>(delay.mTicks) * sSecondsPerTick;
+                },
+                [&](const BAK::ShowDialog& dialog){
+                    waitForClick = RenderDialog(dialog);
+                },
+                [&](const BAK::PlaySoundS& sound){
+                    if (sound.mSoundIndex < 255)
+                    {
+                        AudioA::GetAudioManager().PlaySound(AudioA::SoundIndex{sound.mSoundIndex});
+                    }
+                    else
+                    {
+                        mMusicTracksPlayed++;
+                        AudioA::GetAudioManager().ChangeMusicTrack(AudioA::MusicIndex{sound.mSoundIndex});
+                    }
+                },
+                [&](const auto&){}
             },
-            [&](const BAK::ShowDialog& dialog){
-                waitForClick = RenderDialog(dialog);
-            },
-            [&](const BAK::Update& sr){
-                mSceneElements.back().SetTexture(
-                    Graphics::TextureIndex{mCurrentRenderedFrame++});
-            },
-            [&](const BAK::Purge&){
-                assert(false);
-            },
-            [&](const BAK::PlaySoundS& sound){
-                if (sound.mSoundIndex < 255)
-                {
-                    AudioA::GetAudioManager().PlaySound(AudioA::SoundIndex{sound.mSoundIndex});
-                }
-                else
-                {
-                    mMusicTracksPlayed++;
-                    AudioA::GetAudioManager().ChangeMusicTrack(AudioA::MusicIndex{sound.mSoundIndex});
-                }
-            },
-            [&](const BAK::GotoTag& sa){
-                assert(false);
-            },
-            [&](const auto&){}
-        },
-        action
-    );
+            action
+        );
+
+        if (waitForClick)
+        {
+            return false;
+        }
+    }
+
+    mCurrentFrame.reset();
 
     if (!waitForClick)
     {
+
+        ClearText();
         mDelaying = true;
         mAnimatorStore.AddAnimator(std::make_unique<CallbackDelay>(
             [&](){
                 mDelaying = false;
-                AdvanceAction();
+                AdvanceFrame();
             },
             mDelay));
     }

--- a/gui/dynamicTTM.hpp
+++ b/gui/dynamicTTM.hpp
@@ -10,6 +10,7 @@
 #include "gui/button.hpp"
 #include "gui/textBox.hpp"
 
+#include <optional>
 #include <vector>
 
 namespace Gui {
@@ -22,6 +23,8 @@ class DynamicTTM
 {
     
 public:
+    static constexpr double sSecondsPerTick = .017;
+
     DynamicTTM(
         Graphics::SpriteManager& spriteManager,
         AnimatorStore& animatorStore,
@@ -33,7 +36,7 @@ public:
     Widget* GetScene();
 
     void BeginScene(std::string adsFile, std::string ttmFile);
-    bool AdvanceAction();
+    bool AdvanceFrame();
 
 private:
     bool RenderDialog(const BAK::ShowDialog&);
@@ -52,6 +55,9 @@ private:
 
     std::vector<Widget> mSceneElements;
     BAK::TTMRunner mRunner;
+
+    std::optional<BAK::ScriptFrame> mCurrentFrame{};
+    unsigned mNextAction{0};
 
     bool mDelaying = false;
     double mDelay = 0;


### PR DESCRIPTION
Renamed PURGE and UPDATE to END_SCRIPT and END_FRAME respectively, my interpretation was that UPDATE meant "show the frame", which is kinda true, but END_FRAME is more accurate since it's a delimiter rather than an action. Purge ends the currently running script.

Minor change to the dynamic ttm evaluation, we re-evaluate the ADS conditions at the end of the script. No effect yet, but when I add concurrent script execution this will be useful.