### PR TITLE
Issue #78 - Implement fades

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -34,7 +34,7 @@ list(APPEND APP_BINARIES
     main3d
     #play_book
     #play_cutscene
-    #play_ttm
+    play_ttm
     #show_scene
     #show_imgui
     bmx_explorer

--- a/bak/CMakeLists.txt
+++ b/bak/CMakeLists.txt
@@ -79,6 +79,7 @@ add_library(bak
     startupFiles.hpp startupFiles.cpp
     tags.hpp tags.cpp
     temple.hpp temple.cpp
+
     scene/ttmRenderer.hpp scene/ttmRenderer.cpp
     scene/ttmRunner.hpp scene/ttmRunner.cpp
     textureFactory.hpp textureFactory.cpp

--- a/bak/scene/scene.cpp
+++ b/bak/scene/scene.cpp
@@ -291,10 +291,20 @@ std::vector<ScriptFrame> DecodeTTM(FileBuffer& fb, Tags& tags)
                     SetColors{activeEdgeColor, activeFillColor});
                 break;
             case Actions::FADE_IN:
-                actions.emplace_back(FadeIn{});
+                actions.emplace_back(
+                    FadeIn{
+                        static_cast<unsigned>(args[0]),
+                        static_cast<unsigned>(args[1]),
+                        static_cast<unsigned>(args[2]),
+                        static_cast<unsigned>(args[3])});
                 break;
             case Actions::FADE_OUT:
-                actions.emplace_back(FadeOut{});
+                actions.emplace_back(
+                    FadeOut{
+                        static_cast<unsigned>(args[0]),
+                        static_cast<unsigned>(args[1]),
+                        static_cast<unsigned>(args[2]),
+                        static_cast<unsigned>(args[3])});
                 break;
             case Actions::GOTO_TAG:
                 actions.emplace_back(GotoTag{static_cast<unsigned>(args[0])});

--- a/bak/scene/sceneData.cpp
+++ b/bak/scene/sceneData.cpp
@@ -187,12 +187,14 @@ std::ostream& operator<<(std::ostream& os, const DrawBackground& a)
 
 std::ostream& operator<<(std::ostream& os, const FadeIn& a)
 {
-    return os << "FadeIn{}";
+    return os << "FadeIn{ start: " << a.mStartColor << " steps: " << a.mSteps
+        << " end: " << a.mEndColor << " durationIndex: " << a.mDurationIndex << "}";
 }
 
 std::ostream& operator<<(std::ostream& os, const FadeOut& a)
 {
-    return os << "FadeOut{}";
+    return os << "FadeOut{ start: " << a.mStartColor << " steps: " << a.mSteps
+        << " end: " << a.mEndColor << " durationIndex: " << a.mDurationIndex << "}";
 }
 
 std::ostream& operator<<(std::ostream& os, const EndScript& a)

--- a/bak/scene/sceneData.hpp
+++ b/bak/scene/sceneData.hpp
@@ -225,11 +225,23 @@ struct SetColors
 
 struct FadeIn
 {
+    unsigned mStartColor;
+    unsigned mSteps;
+    unsigned mEndColor;
+    unsigned mDurationIndex;
 };
+
+std::ostream& operator<<(std::ostream&, const FadeIn&);
 
 struct FadeOut
 {
+    unsigned mStartColor;
+    unsigned mSteps;
+    unsigned mEndColor;
+    unsigned mDurationIndex;
 };
+
+std::ostream& operator<<(std::ostream&, const FadeOut&);
 
 struct SetSaveLayer
 {

--- a/bak/scene/ttmRenderer.cpp
+++ b/bak/scene/ttmRenderer.cpp
@@ -144,6 +144,8 @@ bool TTMRenderer::AdvanceFrame()
                 },
                 [&](const EndScript&){},
                 [&](const GotoTag&){},
+                [&](const FadeOut&){},
+                [&](const FadeIn&){},
                 [&](const auto& a){
                     Logging::LogInfo(__FUNCTION__) << "Unhandled action: " << a << "\n";
                 }
@@ -156,6 +158,7 @@ bool TTMRenderer::AdvanceFrame()
 
     return true;
 }
+
 void TTMRenderer::RenderFrame()
 {
     auto frame = mRenderer.GetLayer(Layer::Screen);

--- a/bak/scene/ttmRenderer.hpp
+++ b/bak/scene/ttmRenderer.hpp
@@ -8,6 +8,7 @@
 #include "com/logger.hpp"
 
 #include <unordered_map>
+#include <vector>
 
 namespace BAK {
 

--- a/gui/animatorStore.cpp
+++ b/gui/animatorStore.cpp
@@ -20,8 +20,9 @@ void AnimatorStore::AddAnimator(std::unique_ptr<IAnimator>&& animator)
 void AnimatorStore::OnTimeDelta(double delta)
 {
     mLogger.Spam() << "Ticking : " << delta << "\n";
-    for (auto& animator : mAnimators)
-        animator->OnTimeDelta(delta);
+    const auto ticked = mAnimators.size();
+    for (unsigned i = 0; i < ticked; i++)
+        mAnimators[i]->OnTimeDelta(delta);
 
     mAnimators.erase(
         std::remove_if(

--- a/gui/dynamicTTM.cpp
+++ b/gui/dynamicTTM.cpp
@@ -17,9 +17,41 @@
 
 #include "graphics/types.hpp"
 
+#include "gui/animator.hpp"
 #include "gui/animatorStore.hpp"
 
+#include <array>
+
 namespace Gui {
+
+namespace {
+
+constexpr std::array<double, 7> sFadeDurations = {0, 0.1, 0.4, 0.8, 1.6, 3.2, 6.4};
+
+double FadeDuration(unsigned index)
+{
+    ASSERT(index < sFadeDurations.size());
+    return sFadeDurations[index];
+}
+
+// Hack. The fades currently work by "region" because the first 15 palette
+// members are used to draw the background and text. The rest of the
+// palette colours are used to draw the window area. We choose the fade
+// region based on whether the start color is <16 or not. If it is
+// then the fade applies to full screen, otherwise to the window.
+// If I implemented palette wise rendering at the shader level I could
+// do this properly but leaving that for now.
+constexpr unsigned sFirstPictureColor = 16;
+
+std::pair<glm::vec2, glm::vec2> FadeRegion(unsigned startColor)
+{
+    if (startColor < sFirstPictureColor)
+    {
+        return {glm::vec2{0, 0}, glm::vec2{320, 200}};
+    }
+    return {glm::vec2{15, 11}, glm::vec2{289, 101}};
+}
+}
 
 DynamicTTM::DynamicTTM(
     Graphics::SpriteManager& spriteManager,
@@ -61,6 +93,13 @@ DynamicTTM::DynamicTTM(
         glm::vec2{0},
         glm::vec2{1},
         false 
+    },
+    mFadeRect{
+        RectTag{},
+        glm::vec2{0, 0},
+        glm::vec2{320, 200},
+        glm::vec4{0},
+        false
     },
     mLowerTextBox{
         glm::vec2{15, 125},
@@ -122,9 +161,15 @@ void DynamicTTM::BeginScene(
     }
 
     mDelaying = false;
+    mFading = false;
+    mWaitForClick = false;
+    mFramePresented = false;
     mDelay = 0;
     mCurrentFrame.reset();
     mNextAction = 0;
+    mPaletteSlots.clear();
+    mCurrentPaletteSlot = 0;
+    mFadeRect.SetColor(glm::vec4{0});
     mRunner.LoadTTM(adsFile, ttmFile);
 
     ClearText();
@@ -132,7 +177,7 @@ void DynamicTTM::BeginScene(
 
 bool DynamicTTM::AdvanceFrame()
 {
-    if (mDelaying) return false;
+    if (mDelaying || mFading) return false;
 
     if (!mCurrentFrame)
     {
@@ -149,12 +194,7 @@ bool DynamicTTM::AdvanceFrame()
 
         mCurrentFrame = *frameOpt;
         mNextAction = 0;
-
-        if (mCurrentRenderedFrame < mRenderedFrames.GetTextures().size())
-        {
-            mSceneElements.back().SetTexture(
-                Graphics::TextureIndex{mCurrentRenderedFrame++});
-        }
+        mFramePresented = false;
     }
 
     bool waitForClick = false;
@@ -168,7 +208,22 @@ bool DynamicTTM::AdvanceFrame()
                     mDelay = static_cast<double>(delay.mTicks) * sSecondsPerTick;
                 },
                 [&](const BAK::ShowDialog& dialog){
-                    waitForClick = RenderDialog(dialog);
+                    waitForClick |= RenderDialog(dialog);
+                },
+                [&](const BAK::FadeIn& fade){
+                    waitForClick |= StartFade(
+                        fade.mStartColor, fade.mEndColor, fade.mDurationIndex, true);
+                },
+                [&](const BAK::FadeOut& fade){
+                    waitForClick |= StartFade(
+                        fade.mStartColor, fade.mEndColor, fade.mDurationIndex, false);
+                },
+                [&](const BAK::SlotPalette& sp){
+                    mCurrentPaletteSlot = sp.mSlot;
+                },
+                [&](const BAK::LoadPalette& p){
+                    mPaletteSlots.erase(mCurrentPaletteSlot);
+                    mPaletteSlots.emplace(mCurrentPaletteSlot, BAK::Palette{p.mPalette});
                 },
                 [&](const BAK::PlaySoundS& sound){
                     if (sound.mSoundIndex < 255)
@@ -194,20 +249,103 @@ bool DynamicTTM::AdvanceFrame()
 
     mCurrentFrame.reset();
 
-    if (!waitForClick)
-    {
+    mWaitForClick = waitForClick;
 
-        ClearText();
-        mDelaying = true;
-        mAnimatorStore.AddAnimator(std::make_unique<CallbackDelay>(
-            [&](){
-                mDelaying = false;
-                AdvanceFrame();
-            },
-            mDelay));
-    }
+    FinishFrame();
 
     return false;
+}
+
+glm::vec3 DynamicTTM::GetPaletteColor(unsigned index) const
+{
+    if (!mPaletteSlots.contains(mCurrentPaletteSlot))
+    {
+        return glm::vec3{0};
+    }
+
+    return glm::vec3{mPaletteSlots.at(mCurrentPaletteSlot).GetColor(index)};
+}
+
+bool DynamicTTM::StartFade(unsigned startColor, unsigned endColor, unsigned durationIndex, bool fadeIn)
+{
+    if (mSceneFrame.HaveChild(&mFadeRect))
+        mSceneFrame.RemoveChild(&mFadeRect);
+    mSceneFrame.AddChildBack(&mFadeRect);
+
+    const auto color = GetPaletteColor(endColor);
+    const auto begin = glm::vec4{color, fadeIn ? 1.0f : 0.0f};
+    const auto end = glm::vec4{color, fadeIn ? 0.0f : 1.0f};
+
+    const auto [pos, dims] = FadeRegion(startColor);
+    mFadeRect.SetPosition(pos);
+    mFadeRect.SetDimensions(dims);
+
+    if (fadeIn)
+    {
+        ShowNextFrame();
+        mFramePresented = true;
+    }
+
+    const auto duration = FadeDuration(durationIndex);
+    if (duration == 0)
+    {
+        mFadeRect.SetColor(end);
+        return false;
+    }
+
+    mFadeRect.SetColor(begin);
+    mFading = true;
+    mAnimatorStore.AddAnimator(std::make_unique<LinearAnimator>(
+        duration,
+        begin,
+        end,
+        [this](const auto& delta){
+            mFadeRect.SetColor(mFadeRect.GetDrawInfo().mColor + delta);
+            return false;
+        },
+        [this, end](){
+            mFadeRect.SetColor(end);
+            mFading = false;
+            AdvanceFrame();
+        }));
+    return true;
+}
+
+void DynamicTTM::FinishFrame()
+{
+    if (!mFramePresented)
+    {
+        ShowNextFrame();
+        mFramePresented = true;
+    }
+
+    mFadeRect.SetColor(glm::vec4{0});
+
+    if (!mWaitForClick)
+    {
+        ClearText();
+        Delay(mDelay);
+    }
+}
+
+void DynamicTTM::ShowNextFrame()
+{
+    if (mCurrentRenderedFrame < mRenderedFrames.GetTextures().size())
+    {
+        mSceneElements.back().SetTexture(
+            Graphics::TextureIndex{mCurrentRenderedFrame++});
+    }
+}
+
+void DynamicTTM::Delay(double seconds)
+{
+    mDelaying = true;
+    mAnimatorStore.AddAnimator(std::make_unique<CallbackDelay>(
+        [&](){
+            mDelaying = false;
+            AdvanceFrame();
+        },
+        seconds));
 }
 
 bool DynamicTTM::RenderDialog(const BAK::ShowDialog& dialog)

--- a/gui/dynamicTTM.hpp
+++ b/gui/dynamicTTM.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "bak/palette.hpp"
 #include "bak/scene/ttmRunner.hpp"
 
 #include "com/logger.hpp"
@@ -10,7 +11,10 @@
 #include "gui/button.hpp"
 #include "gui/textBox.hpp"
 
+#include <glm/glm.hpp>
+
 #include <optional>
+#include <unordered_map>
 #include <vector>
 
 namespace Gui {
@@ -40,7 +44,12 @@ public:
 
 private:
     bool RenderDialog(const BAK::ShowDialog&);
+    bool StartFade(unsigned startColor, unsigned endColor, unsigned durationIndex, bool fadeIn);
+    void ShowNextFrame();
+    void FinishFrame();
+    void Delay(double seconds);
     void ClearText();
+    glm::vec3 GetPaletteColor(unsigned index) const;
 
     Graphics::SpriteManager& mSpriteManager;
     AnimatorStore& mAnimatorStore;
@@ -48,6 +57,7 @@ private:
     Widget mSceneFrame;
     Widget mDialogBackground;
     Widget mRenderedElements;
+    Widget mFadeRect;
 
     TextBox mLowerTextBox;
     Button mPopup;
@@ -60,7 +70,13 @@ private:
     unsigned mNextAction{0};
 
     bool mDelaying = false;
+    bool mFading = false;
+    bool mWaitForClick = false;
+    bool mFramePresented = false;
     double mDelay = 0;
+
+    std::unordered_map<unsigned, BAK::Palette> mPaletteSlots;
+    unsigned mCurrentPaletteSlot{0};
 
     Graphics::TextureStore mRenderedFrames;
     Graphics::SpriteManager::TemporarySpriteSheet mRenderedFramesSheet;


### PR DESCRIPTION
Implement FadeIn/Out actions. Signal a fade widget instead of rendering these frame by frame as that would be too expensive in terms of memory.

In future I could render cutscenes/ttm scenes with a palette based shader, to do native fade, but for now not doing that and have added some hacks to fade the correct region of the screen which hold for the cutscenes in BaK.