### PR TITLE
Issue #185 - Display chapter recap between cutscenes

### DIFF
--- a/bak/dialogSources.cpp
+++ b/bak/dialogSources.cpp
@@ -49,6 +49,11 @@ KeyTarget DialogSources::GetChapterStartText(Chapter chapter)
     return KeyTarget{mChapterFullMapScreenText + (chapter.mValue - 1)};
 }
 
+KeyTarget DialogSources::GetChapterRecap(Chapter chapter)
+{
+    return KeyTarget{mChapterRecapText + (chapter.mValue - 1)};
+}
+
 Target DialogSources::GetChoiceResult(KeyTarget dialog, unsigned index)
 {
     const auto& choices = DialogStore::Get().GetSnippet(dialog).GetChoices();

--- a/bak/dialogSources.hpp
+++ b/bak/dialogSources.hpp
@@ -23,6 +23,7 @@ public:
     static KeyTarget GetSpellCastDialog(unsigned spell);
     static KeyTarget GetTTMDialogKey(unsigned index);
     static KeyTarget GetChapterStartText(Chapter chapter);
+    static KeyTarget GetChapterRecap(Chapter chapter);
     static Target GetChoiceResult(KeyTarget dialog, unsigned index);
     static std::optional<Target> GetConditionNotification(Condition);
     
@@ -201,6 +202,7 @@ public:
 
     static constexpr auto mAfterNagoCombatSetKeys = KeyTarget{0x1cfdf1};
     static constexpr auto mChapterFullMapScreenText = 0x126;
+    static constexpr auto mChapterRecapText = 0x186ab6;
     static constexpr auto mStartOfChapterActions =
         KeyTarget{0x1e8497};
     static constexpr auto mDragonsBreath = 0xc7;

--- a/gui/IGuiManager.hpp
+++ b/gui/IGuiManager.hpp
@@ -51,6 +51,7 @@ public:
     virtual void ShowCast(bool inCombat) = 0;
     virtual void ShowFullMap() = 0;
     virtual void ShowGameStartMap() = 0;
+    virtual void ShowChapterRecap(BAK::Chapter chapter, std::function<void()>&& dismissed) = 0;
     virtual void ShowTeleport(unsigned sourceTemple, BAK::ShopStats* temple) = 0;
     virtual void ShowCureScreen(
         unsigned templeNumber,

--- a/gui/bookPlayer.cpp
+++ b/gui/bookPlayer.cpp
@@ -111,7 +111,11 @@ void BookPlayer::RenderPage(const BAK::Page& page)
     mTextBox.SetDimensions(mBook->mPages[mCurrentPage].mDims / 2);
     auto [pos, remaining] = mTextBox.SetText(mFont, mText, false, false, false, .82, 2.0);
     mText = remaining;
-    Logging::LogDebug(__FUNCTION__) << "Remaining text: " << mText << "\n";
+    Logging::LogDebug(__FUNCTION__) << "Remaining text: [" << mText << "]\n";
+    if (mText.find_first_not_of(" \n\t\xf8\xf3") == std::string::npos)
+    {
+        mText = "";
+    }
 
     mBackground.AddChildBack(&mTextBox);
 }

--- a/gui/contents.cpp
+++ b/gui/contents.cpp
@@ -21,7 +21,8 @@ ContentsScreen::ContentsScreen(
     Graphics::SpriteManager& spriteManager,
     const Backgrounds& backgrounds,
     const Font& font,
-    LeaveContentsFn&& leaveContentsFn)
+    LeaveContentsFn&& leaveContentsFn,
+    CutscenesFinishedFn&& cutscenesFinishedFn)
 :
     Widget{
         RectTag{},
@@ -36,6 +37,7 @@ ContentsScreen::ContentsScreen(
     mBackgrounds{backgrounds},
     mLayout{sLayoutFile},
     mLeaveContentsFn{std::move(leaveContentsFn)},
+    mCutscenesFinishedFn{std::move(cutscenesFinishedFn)},
     mUnlockedChapters{9},
     mFrame{
         ImageTag{},
@@ -152,12 +154,37 @@ void ContentsScreen::AddChildren()
     }
 }
 
+void ContentsScreen::ContinueCutscene()
+{
+    if (mCutsceneState == State::StartOfChapter)
+    {
+        if (mUnlockedChapters <= mChapter.mValue)
+        {
+            std::invoke(mCutscenesFinishedFn);
+            return;
+        }
+        mCutsceneState = State::ChapterRecap;
+        mGuiManager.ShowChapterRecap(mChapter, [this]{ ContinueCutscene(); });
+    }
+    else if (mCutsceneState == State::ChapterRecap)
+    {
+        mCutsceneState = State::EndOfChapter;
+        mGuiManager.PlayCutscene(
+            BAK::CutsceneList::GetFinishScene(mChapter),
+            [this]{ ContinueCutscene(); });
+    }
+    else
+    {
+        std::invoke(mCutscenesFinishedFn);
+    }
+}
+
 void ContentsScreen::PlayChapter(BAK::Chapter chapter)
 {
-    auto start = BAK::CutsceneList::GetStartScene(chapter);
-    auto finish = BAK::CutsceneList::GetFinishScene(chapter);
-    start.insert(start.end(), finish.begin(), finish.end());
-    mGuiManager.PlayCutscene(start, []{});
+    mChapter = chapter;
+    mCutsceneState = State::StartOfChapter;
+    auto scenes = BAK::CutsceneList::GetStartScene(chapter);
+    mGuiManager.PlayCutscene(scenes, [this]{ ContinueCutscene(); });
 }
 
 }

--- a/gui/contents.hpp
+++ b/gui/contents.hpp
@@ -28,13 +28,22 @@ public:
     static constexpr auto sExit = 9;
 
     using LeaveContentsFn = std::function<void()>;
+    using CutscenesFinishedFn = std::function<void()>;
+
+    enum class State
+    {
+        StartOfChapter,
+        ChapterRecap,
+        EndOfChapter
+    };
 
     ContentsScreen(
         IGuiManager& guiManager,
         Graphics::SpriteManager& spriteManager,
         const Backgrounds& backgrounds,
         const Font& font,
-        LeaveContentsFn&& leaveContentsFn);
+        LeaveContentsFn&& leaveContentsFn,
+        CutscenesFinishedFn&& cutscenesFinishedFn);
 
     void SetUnlockedChapters(unsigned unlocked);
 
@@ -43,6 +52,7 @@ private:
     void PlayChapter(BAK::Chapter chapter);
     void ShowTooltip(unsigned buttonIndex);
     void DismissTooltip();
+    void ContinueCutscene();
 
     IGuiManager& mGuiManager;
     Graphics::SpriteManager::TemporarySpriteSheet mSpriteSheet;
@@ -51,6 +61,7 @@ private:
 
     BAK::Layout mLayout;
     LeaveContentsFn mLeaveContentsFn;
+    CutscenesFinishedFn mCutscenesFinishedFn;
     unsigned mUnlockedChapters;
 
     using ChapterButton = Clickable<
@@ -63,6 +74,8 @@ private:
     ClickButton mTooltipPopup;
 
     bool mShowingTooltip{false};
+    State mCutsceneState{};
+    BAK::Chapter mChapter;
 
 };
 

--- a/gui/dynamicTTM.cpp
+++ b/gui/dynamicTTM.cpp
@@ -177,8 +177,12 @@ void DynamicTTM::BeginScene(
 
 bool DynamicTTM::AdvanceFrame()
 {
-    if (mDelaying || mFading) return false;
+    if (mDelaying || mFading)
+    {
+        return false;
+    }
 
+    mLogger.Debug() << __FUNCTION__ << " next action: " << mNextAction << " Current frame: " << bool{mCurrentFrame} << "\n";
     if (!mCurrentFrame)
     {
         auto frameOpt = mRunner.GetNextFrame();
@@ -198,6 +202,7 @@ bool DynamicTTM::AdvanceFrame()
     }
 
     bool waitForClick = false;
+    bool scriptFinished = false;
     while (mNextAction < mCurrentFrame->mActions.size())
     {
         const auto& action = mCurrentFrame->mActions[mNextAction++];
@@ -236,6 +241,9 @@ bool DynamicTTM::AdvanceFrame()
                         AudioA::GetAudioManager().ChangeMusicTrack(AudioA::MusicIndex{sound.mSoundIndex});
                     }
                 },
+                [&](const BAK::EndScript&){
+                    scriptFinished = true;
+                },
                 [&](const auto&){}
             },
             action
@@ -251,7 +259,12 @@ bool DynamicTTM::AdvanceFrame()
 
     mWaitForClick = waitForClick;
 
-    FinishFrame();
+    FinishFrame(scriptFinished);
+
+    if (scriptFinished)
+    {
+        AdvanceFrame();
+    }
 
     return false;
 }
@@ -269,7 +282,9 @@ glm::vec3 DynamicTTM::GetPaletteColor(unsigned index) const
 bool DynamicTTM::StartFade(unsigned startColor, unsigned endColor, unsigned durationIndex, bool fadeIn)
 {
     if (mSceneFrame.HaveChild(&mFadeRect))
+    {
         mSceneFrame.RemoveChild(&mFadeRect);
+    }
     mSceneFrame.AddChildBack(&mFadeRect);
 
     const auto color = GetPaletteColor(endColor);
@@ -311,7 +326,7 @@ bool DynamicTTM::StartFade(unsigned startColor, unsigned endColor, unsigned dura
     return true;
 }
 
-void DynamicTTM::FinishFrame()
+void DynamicTTM::FinishFrame(bool scriptFinished)
 {
     if (!mFramePresented)
     {
@@ -319,7 +334,10 @@ void DynamicTTM::FinishFrame()
         mFramePresented = true;
     }
 
-    mFadeRect.SetColor(glm::vec4{0});
+    if (!scriptFinished)
+    {
+        mFadeRect.SetColor(glm::vec4{0});
+    }
 
     if (!mWaitForClick)
     {

--- a/gui/dynamicTTM.hpp
+++ b/gui/dynamicTTM.hpp
@@ -46,7 +46,7 @@ private:
     bool RenderDialog(const BAK::ShowDialog&);
     bool StartFade(unsigned startColor, unsigned endColor, unsigned durationIndex, bool fadeIn);
     void ShowNextFrame();
-    void FinishFrame();
+    void FinishFrame(bool scriptFinished);
     void Delay(double seconds);
     void ClearText();
     glm::vec3 GetPaletteColor(unsigned index) const;

--- a/gui/fullMap.cpp
+++ b/gui/fullMap.cpp
@@ -15,6 +15,7 @@
 #include "gui/core/widget.hpp"
 
 #include <glm/glm.hpp>
+#include <functional>
 #include <memory>
 
 namespace Gui {
@@ -59,7 +60,7 @@ FullMap::FullMap(
         Color::buttonBackground,
         Color::buttonHighlight,
         Color::buttonShadow,
-        Color::black
+        Color::black,
     },
     mPopupText{
         glm::vec2{},
@@ -74,7 +75,6 @@ FullMap::FullMap(
         false
     },  
     mTowns{},
-    mGameStartScreenMode{false},
     mLogger{Logging::LogState::GetLogger("Gui::FullMap")}
 {
     mTowns.reserve(mFMapTowns.GetTowns().size());
@@ -90,18 +90,29 @@ FullMap::FullMap(
     mPopup.AddChildBack(&mPopupText);
 }
 
+[[nodiscard]] bool FullMap::OnMouseEvent(const MouseEvent& event)
+{
+    if (mDisplayMode == DisplayMode::ChapterRecap
+        && std::holds_alternative<LeftMousePress>(event))
+    {
+        DismissPopup();
+    }
+
+    return Widget::OnMouseEvent(event);
+}
+
 void FullMap::DisplayMapMode()
 {
-    mGameStartScreenMode = false;
+    mDisplayMode = DisplayMode::Normal;
     StartPlayerPositionFlasher();
     AddChildren();
 }
 
 void FullMap::DisplayGameStartMode(BAK::Chapter chapter, BAK::MapLocation location, bool shortTransition)
 {
-    mGameStartScreenMode = true;
+    mDisplayMode = DisplayMode::GameStart;
     SetPlayerLocation(location);
-    DisplayGameStart(chapter);
+    PopulatePopup(BAK::DialogSources::GetChapterStartText(chapter));
     AddChildren();
 
     StartPlayerPositionFlasher();
@@ -113,6 +124,14 @@ void FullMap::DisplayGameStartMode(BAK::Chapter chapter, BAK::MapLocation locati
                 mPlayerPositionFlasher->Stop();
             },
             shortTransition ? 0.1 : 3));
+}
+
+void FullMap::DisplayChapterRecap(BAK::Chapter chapter, std::function<void()>&& dismissed)
+{
+    mDisplayMode = DisplayMode::ChapterRecap;
+    mPopupDismissed = std::move(dismissed);
+    PopulatePopup(BAK::DialogSources::GetChapterRecap(chapter));
+    AddChildren();
 }
 
 void FullMap::UpdateLocation()
@@ -142,18 +161,26 @@ void FullMap::SetPlayerLocation(BAK::MapLocation location)
     UpdatePlayerPositionIcon();
 }
 
-void FullMap::DisplayGameStart(BAK::Chapter chapter)
+void FullMap::PopulatePopup(BAK::Target dialog)
 {
-    const auto& snippet = BAK::DialogStore::Get().GetSnippet(
-        BAK::DialogSources::GetChapterStartText(chapter));
+    const auto& snippet = BAK::DialogStore::Get().GetSnippet(dialog);
     assert(snippet.GetPopup());
     const auto popup = snippet.GetPopup();
-    mLogger.Debug() << "Show snippet;" << snippet << "\n";
     mPopup.SetPosition(popup->mPos);
     mPopup.SetDimensions(popup->mDims);
     mPopupText.SetPosition(glm::vec2{1});
     mPopupText.SetDimensions(popup->mDims);
     mPopupText.SetText(mFont, snippet.GetText(), true, true);
+}
+
+void FullMap::DismissPopup()
+{
+    if (mDisplayMode == DisplayMode::ChapterRecap && mPopupDismissed)
+    {
+        auto dismissed = std::move(mPopupDismissed);
+        mPopupDismissed = nullptr;
+        std::invoke(dismissed);
+    }
 }
 
 void FullMap::StartPlayerPositionFlasher()
@@ -189,7 +216,8 @@ void FullMap::AddChildren()
 {
     ClearChildren();
 
-    if (mGameStartScreenMode)
+    if (mDisplayMode == DisplayMode::GameStart
+        || mDisplayMode == DisplayMode::ChapterRecap)
     {
         AddChildBack(&mPopup);
     }
@@ -200,7 +228,10 @@ void FullMap::AddChildren()
             AddChildBack(&t);
     }
 
-    AddChildBack(&mPlayerLocation);
+    if (mDisplayMode != DisplayMode::ChapterRecap)
+    {
+        AddChildBack(&mPlayerLocation);
+    }
 }
 
 }

--- a/gui/fullMap.hpp
+++ b/gui/fullMap.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
 #include "bak/coordinates.hpp"
+#include "bak/dialog.hpp"
 #include "bak/fmap.hpp"
 #include "bak/layout.hpp"
 
 #include "gui/clickButton.hpp"
 #include "gui/townLabel.hpp"
+#include "gui/core/clickable.hpp"
 #include "gui/core/widget.hpp"
 
 #include <glm/glm.hpp>
@@ -26,6 +28,13 @@ class TickAnimator;
 class FullMap : public Widget
 {
 public:
+    enum class DisplayMode
+    {
+        Normal,
+        GameStart,
+        ChapterRecap
+    };
+
     static constexpr auto sLayoutFile = "REQ_FMAP.DAT";
 
     static constexpr auto sExitWidget = 0;
@@ -37,8 +46,11 @@ public:
         const Font& font,
         BAK::GameState& gameState);
     
+    [[nodiscard]] bool OnMouseEvent(const MouseEvent& event) override;
+
     void DisplayMapMode();
     void DisplayGameStartMode(BAK::Chapter chapter, BAK::MapLocation location, bool shortTransition);
+    void DisplayChapterRecap(BAK::Chapter chapter, std::function<void()>&& dismissed);
     void UpdateLocation();
 
 private:
@@ -46,7 +58,8 @@ private:
         BAK::ZoneNumber zone,
         BAK::GamePositionAndHeading location);
     void SetPlayerLocation(BAK::MapLocation location);
-    void DisplayGameStart(BAK::Chapter chapter);
+    void PopulatePopup(BAK::Target);
+    void DismissPopup();
     void StartPlayerPositionFlasher();
     void UpdatePlayerPositionIcon();
     void AddChildren();
@@ -64,6 +77,7 @@ private:
     ClickButton mExitButton;
     Button mPopup;
     TextBox mPopupText;
+    std::function<void()> mPopupDismissed;
 
     Widget mPlayerLocation;
     std::vector<TownLabel> mTowns{};
@@ -72,7 +86,7 @@ private:
     int mPlayerPositionIconPulseDirection{1};
     TickAnimator* mPlayerPositionFlasher{};
 
-    bool mGameStartScreenMode{};
+    DisplayMode mDisplayMode{DisplayMode::Normal};
 
     const Logging::Logger& mLogger;
 };

--- a/gui/guiManager.cpp
+++ b/gui/guiManager.cpp
@@ -5,6 +5,7 @@
 #include "bak/partyChangeCache.hpp"
 #include "bak/startupFiles.hpp"
 
+#include "bak/types.hpp"
 #include "gui/IDialogScene.hpp"
 #include "gui/cursor.hpp"
 
@@ -251,7 +252,10 @@ void GuiManager::PlayCutscene(
 
 void GuiManager::CutsceneFinished()
 {
-    mCutsceneFinished();
+    // PlayCutscene may be called from within the callback
+    auto finished = std::move(mCutsceneFinished);
+    mCutsceneFinished = nullptr;
+    finished();
 }
 
 bool GuiManager::InMainView() const
@@ -659,7 +663,19 @@ void GuiManager::ShowGameStartMap()
 {
     DoFade(1.0, [this]{
         auto checkMainView = PopScreen();
-        mFullMap.DisplayGameStartMode(mGameState.GetChapter(), mGameState.GetMapLocation(), mDebugDisableFades);
+        mFullMap.DisplayGameStartMode(
+            mGameState.GetChapter(),
+            mGameState.GetMapLocation(),
+            mDebugDisableFades);
+        PushScreen(&mFullMap);
+    });
+}
+
+void GuiManager::ShowChapterRecap(BAK::Chapter chapter, std::function<void()>&& dismissed)
+{
+    DoFade(1.0, [this, chapter, dismissed=std::move(dismissed)]() mutable {
+        auto checkMainView = PopScreen();
+        mFullMap.DisplayChapterRecap(chapter, std::move(dismissed));
         PushScreen(&mFullMap);
     });
 }

--- a/gui/guiManager.hpp
+++ b/gui/guiManager.hpp
@@ -124,6 +124,7 @@ public:
     void ShowCast(bool inCombat) override;
     void ShowFullMap() override;
     void ShowGameStartMap() override;
+    void ShowChapterRecap(BAK::Chapter chapter, std::function<void()>&& dismissed) override;
     void ShowCureScreen(
         unsigned templeNumber,
         unsigned cureFactor,

--- a/gui/mainMenuScreen.cpp
+++ b/gui/mainMenuScreen.cpp
@@ -106,7 +106,8 @@ MainMenuScreen::MainMenuScreen(
         spriteManager,
         backgrounds,
         font,
-        [this]{ BackToMainMenu(); }
+        [this]{ BackToMainMenu(); },
+        [this]{ mGuiManager.EnterMainMenu(mGameRunning); }
     },
     mSaveManager{
         (Paths::Get().GetBakDirectoryPath() / "GAMES").string()},


### PR DESCRIPTION
Display the chapter recap between cutscenes. Tidy up cutscene sequence in general. Also inhibit the recap and finished cutscene depending on whether the chapter was completed or not.