### PR TITLE
Issue #78 - Fixes for dialog

### DIFF
--- a/app/play_ttm.cpp
+++ b/app/play_ttm.cpp
@@ -8,6 +8,7 @@
 #include "gui/animatorStore.hpp"
 #include "gui/backgrounds.hpp"
 #include "gui/fontManager.hpp"
+#include "gui/guiManager.hpp"
 #include "gui/core/mouseEvent.hpp"
 #include "gui/dynamicTTM.hpp"
 #include "gui/window.hpp"
@@ -84,9 +85,17 @@ int main(int argc, char** argv)
 
     Gui::AnimatorStore animatorStore{};
 
+    auto gameState = BAK::GameState{};
+    auto guiManager = Gui::GuiManager{
+        rootWidget.GetCursor(),
+        spriteManager,
+        gameState
+    };
+
     auto dynamicTTM = Gui::DynamicTTM(
         spriteManager,
         animatorStore,
+        guiManager,
         font,
         backgrounds,
         [&](){ },

--- a/bak/gameState.cpp
+++ b/bak/gameState.cpp
@@ -99,6 +99,11 @@ void GameState::LoadGame(std::string savePath)
     mTileVisibility = LoadTileVisibility(mGameData.GetFileBuffer());
 }
 
+bool GameState::IsGameLoaded() const
+{
+    return mGameData.IsLoaded();
+}
+
 const Party& GameState::GetParty() const
 {
     return mGameData.mParty;

--- a/bak/gameState.hpp
+++ b/bak/gameState.hpp
@@ -78,6 +78,7 @@ public:
     const GameData& GetGameData() const { return mGameData; }
 
     void LoadGame(std::string savePath);
+    bool IsGameLoaded() const;
 
     const Party& GetParty() const;
     Party& GetParty();

--- a/gui/cutscenePlayer.cpp
+++ b/gui/cutscenePlayer.cpp
@@ -29,6 +29,7 @@ CutscenePlayer::CutscenePlayer(
     mDynamicTTM(
         spriteManager,
         animatorStore,
+        guiManager,
         font,
         background,
         [&](){ SceneFinished(); },

--- a/gui/dynamicTTM.cpp
+++ b/gui/dynamicTTM.cpp
@@ -56,6 +56,7 @@ std::pair<glm::vec2, glm::vec2> FadeRegion(unsigned startColor)
 DynamicTTM::DynamicTTM(
     Graphics::SpriteManager& spriteManager,
     AnimatorStore& animatorStore,
+    IGuiManager& guiManager,
     const Font& font,
     const Backgrounds& backgrounds,
     std::function<void()>&& sceneFinished,
@@ -63,6 +64,7 @@ DynamicTTM::DynamicTTM(
 :
     mSpriteManager{spriteManager},
     mAnimatorStore{animatorStore},
+    mGuiManager{guiManager},
     mFont{font},
     mSceneFrame{
         Graphics::DrawMode::Rect,
@@ -342,7 +344,10 @@ void DynamicTTM::FinishFrame(bool scriptFinished)
 
     if (!mWaitForClick)
     {
-        ClearText();
+        if (mDialogType == 1 || mDialogType == 4)
+        {
+            ClearText();
+        }
         Delay(mDelay);
     }
 }
@@ -367,15 +372,35 @@ void DynamicTTM::Delay(double seconds)
         seconds));
 }
 
+void DynamicTTM::DialogFinished(const std::optional<BAK::ChoiceIndex>&)
+{
+    mLogger.Debug() << __FUNCTION__ << " DynamicTTM\n";
+    AdvanceFrame();
+}
+
 bool DynamicTTM::RenderDialog(const BAK::ShowDialog& dialog)
 {
-    // mDialogType == 5 - display dialog using RunDialog (i.e. No actor names, no default bold)
-    // mDialogType == 1 and 4 - similar to above... not sure the difference
-    // mDialogType == 3 - same as above - no wait
-    // mDialogType == 0 - the usual method
+    // mDialogType == 0 - the usual method with bolded text and actor names
+    // mDialogType == 3 - same as above - but advances the script without
+    //                    waiting for a click
+    // mDialogType == 1 and 4 - Same as 0 but clear text as soon as the frame ends and is typically a popup
+    // mDialogType == 5 - display dialog using RunDialog
+    mLogger.Debug() << __FUNCTION__ << " " << dialog << "\n";
+    mDialogType = dialog.mDialogType;
     if (dialog.mDialogType == 2)
     {
         mDisplayBook(dialog.mDialogKey.value_or(0));
+        return true;
+    }
+
+    if (dialog.mDialogType == 5)
+    {
+        mLogger.Debug() << __FUNCTION__ << " running dialog with gui manager " << dialog << "\n";
+        mGuiManager.StartDialog(
+            BAK::DialogSources::GetTTMDialogKey(*dialog.mDialogKey),
+            false,
+            false,
+            this);
         return true;
     }
 
@@ -409,7 +434,8 @@ bool DynamicTTM::RenderDialog(const BAK::ShowDialog& dialog)
             }
         }
 
-        return true;
+        // Dialog type 3 doesn't wait for click
+        return mDialogType != 3;
     }
     else
     {

--- a/gui/dynamicTTM.hpp
+++ b/gui/dynamicTTM.hpp
@@ -2,6 +2,8 @@
 
 #include "bak/palette.hpp"
 #include "bak/scene/ttmRunner.hpp"
+#include "gui/IGuiManager.hpp"
+#include "gui/IDialogScene.hpp"
 
 #include "com/logger.hpp"
 
@@ -23,7 +25,7 @@ class AnimatorStore;
 class Backgrounds;
 class Font;
 
-class DynamicTTM
+class DynamicTTM : public IDialogScene
 {
     
 public:
@@ -32,6 +34,7 @@ public:
     DynamicTTM(
         Graphics::SpriteManager& spriteManager,
         AnimatorStore& animatorStore,
+        IGuiManager& guiManager,
         const Font& font,
         const Backgrounds& background,
         std::function<void()>&& sceneFinished,
@@ -41,6 +44,10 @@ public:
 
     void BeginScene(std::string adsFile, std::string ttmFile);
     bool AdvanceFrame();
+
+    void DisplayNPCBackground() override {};
+    void DisplayPlayerBackground() override {};
+    void DialogFinished(const std::optional<BAK::ChoiceIndex>&) override;
 
 private:
     bool RenderDialog(const BAK::ShowDialog&);
@@ -53,6 +60,7 @@ private:
 
     Graphics::SpriteManager& mSpriteManager;
     AnimatorStore& mAnimatorStore;
+    IGuiManager& mGuiManager;
     const Font& mFont;
     Widget mSceneFrame;
     Widget mDialogBackground;
@@ -83,6 +91,7 @@ private:
     unsigned mCurrentRenderedFrame{0};
     bool mWaitAtNextUpdate{false};
     unsigned mMusicTracksPlayed{0};
+    unsigned mDialogType{0};
 
     std::function<void()> mSceneFinished;
     std::function<void(unsigned)> mDisplayBook;

--- a/gui/mainView.cpp
+++ b/gui/mainView.cpp
@@ -299,6 +299,10 @@ void MainView::UpdatePartyMembers(const BAK::GameState& gameState)
 
     mCharacters.clear();
     mCharacters.reserve(3);
+    if (!gameState.IsGameLoaded())
+    {
+        return;
+    }
 
     const auto& party = gameState.GetParty();
     mLogger.Spam() << "Updating Party: " << party<< "\n";


### PR DESCRIPTION
Fixes handling for the different dialog types

* Dialog type 0 - unchanged, vanilla dialog display
* Dialog type 1, 4 - the popups in map view, clears text view when clicked through
* Dialog type 3 - like 0, but does not wait for a click
* Dialog type 5 - just runs the dialog through the usual dialog runner