### PR TITLE
Issue #353 - When in overhead view, go to FPS view for encounters

### DIFF
--- a/game/gameRunner.cpp
+++ b/game/gameRunner.cpp
@@ -152,6 +152,7 @@ void GameRunner::DoTeleport(BAK::Encounter::Teleport teleport)
 
 void GameRunner::LoadGame(std::string savePath, std::optional<BAK::Chapter> chapter)
 {
+    mWasInOverheadView = false;
     mGameState.LoadGame(savePath);
     if (chapter)
     {
@@ -167,7 +168,9 @@ void GameRunner::ToggleFollowRoad()
 
 void GameRunner::ShowOverheadView()
 {
+    mWasInOverheadView = false;
     mGameState.SetOverheadView(true);
+    mGuiManager.GetMainView().SetInMapView(true);
     ToggleUndergroundModels();
     UpdateOrthoProjection(mZoomManager.CalculateZoom(GetOrthoViewDimensions()));
     UpdateOverheadVisibility();
@@ -176,7 +179,9 @@ void GameRunner::ShowOverheadView()
 
 void GameRunner::ShowFirstPersonView()
 {
+    mWasInOverheadView = false;
     mGameState.SetOverheadView(false);
+    mGuiManager.GetMainView().SetInMapView(false);
     ToggleUndergroundModels();
 
     mViewCamera.UsePerspectiveMatrix();
@@ -185,8 +190,22 @@ void GameRunner::ShowFirstPersonView()
     ShowOverheadHidden();
 }
 
+void GameRunner::CheckAndRestoreOverheadView()
+{
+    if (!mWasInOverheadView
+        || !mGuiManager.InMainView()
+        || mGuiManager.GetCombatSequenceActive())
+    {
+        return;
+    }
+
+    ShowOverheadView();
+}
+
 void GameRunner::UpdateViewCamera()
 {
+    CheckAndRestoreOverheadView();
+
     if (mGameState.GetOverheadView())
     {
         auto position = mPartyCamera.GetPosition();
@@ -1048,6 +1067,20 @@ void GameRunner::EnterCombatFromEncounter()
         });
 }
 
+bool GameRunner::DoEncounter(const BAK::Encounter::Encounter& encounter)
+{
+    const bool wasOverhead = mGameState.GetOverheadView() && mGuiManager.InMainView();
+    const auto handled = mEncounterHandler.DoEncounter(encounter);
+
+    if (wasOverhead && !mGuiManager.InMainView())
+    {
+        ShowFirstPersonView();
+        mWasInOverheadView = true;
+    }
+
+    return handled;
+}
+
 bool GameRunner::CheckAndDoEncounter(glm::uvec2 position)
 {
     auto intersectables = mSystems->RunIntersection(
@@ -1065,7 +1098,7 @@ bool GameRunner::CheckAndDoEncounter(glm::uvec2 position)
         mActiveEncounter = encounter;
         if (mActiveEncounter)
         {
-            auto handled = mEncounterHandler.DoEncounter(*mActiveEncounter);
+            auto handled = DoEncounter(*mActiveEncounter);
             if (handled)
             {
                 return true;
@@ -1145,7 +1178,7 @@ void GameRunner::RunGameUpdate(bool advanceTime)
             if (encounter)
             {
                 mActiveEncounter = encounter;
-                auto handled = mEncounterHandler.DoEncounter(*encounter);
+                auto handled = DoEncounter(*encounter);
                 if (handled)
                 {
                     break;

--- a/game/gameRunner.hpp
+++ b/game/gameRunner.hpp
@@ -100,6 +100,7 @@ public:
     void LoadSystems();
 
     void DoGenericContainer(BAK::EntityType et, BAK::GenericContainer& container, BAK::EntityIndex entityIndex);
+    bool DoEncounter(const BAK::Encounter::Encounter& encounter);
     bool CheckAndDoEncounter(glm::uvec2 position);
     
     void RunGameUpdate(bool advanceTime);
@@ -165,6 +166,7 @@ private:
     void AnimateCrossPit(BAK::EntityIndex entityIndex);
     void UpdatePartyMarkerScale(glm::uvec2 orthoDims);
     void UpdatePartyMarker();
+    void CheckAndRestoreOverheadView();
     glm::uvec2 GetOrthoViewDimensions() const;
     float GetZoneFieldOfView() const;
     void UpdateOrthoProjection(glm::uvec2 dims);
@@ -210,6 +212,7 @@ public:
     glm::vec3 mSavedCameraPos{};
     glm::vec2 mSavedCameraAngle{};
     bool mCombatCameraActive{false};
+    bool mWasInOverheadView{false};
     BAK::CardinalDirection mRetreatDirection{};
 
     bool mGridVisible{false};

--- a/gui/IMainView.hpp
+++ b/gui/IMainView.hpp
@@ -13,6 +13,7 @@ public:
     virtual void SetFollowRoadActive(bool active) = 0;
     virtual void SetZoomOutVisible(bool visible) = 0;
     virtual void SetZoomInVisible(bool visible) = 0;
+    virtual void SetInMapView(bool inMapView) = 0;
 
     virtual ~IMainView() = default;
 };

--- a/gui/mainView.cpp
+++ b/gui/mainView.cpp
@@ -139,8 +139,6 @@ void MainView::HandleMapView()
     {
         mGuiManager.DoFade(1.0, [&]{
             mGuiManager.GetCameraManager().ShowOverheadView();
-            mIsInMapView = true;
-            AddChildren();
         });
     }
 }
@@ -151,8 +149,6 @@ void MainView::HandleExit()
     {
         mGuiManager.DoFade(1.0, [&]{
             mGuiManager.GetCameraManager().ShowFirstPersonView();
-            mIsInMapView = false;
-            AddChildren();
         });
     }
     else
@@ -255,6 +251,15 @@ void MainView::SetZoomInVisible(bool visible)
 {
     mZoomInVisible = visible;
     AddChildren();
+}
+
+void MainView::SetInMapView(bool inMapView)
+{
+    if (inMapView != mIsInMapView)
+    {
+        mIsInMapView = inMapView;
+        AddChildren();
+    }
 }
 
 bool MainView::OnMouseEvent(const MouseEvent& event)

--- a/gui/mainView.hpp
+++ b/gui/mainView.hpp
@@ -57,6 +57,7 @@ public:
     void SetFollowRoadActive(bool active) override;
     void SetZoomOutVisible(bool visible) override;
     void SetZoomInVisible(bool visible) override;
+    void SetInMapView(bool inMapView) override;
     [[nodiscard]] bool OnMouseEvent(const MouseEvent& event) override;
 private:
     void AddChildren();


### PR DESCRIPTION
e.g. when encountering a dialogue we need to show the FPS view, not remain in the overhead view.