### PR TITLE
Issue #318 - Use the same probe amount as original bak

### DIFF
--- a/bak/constants.hpp
+++ b/bak/constants.hpp
@@ -15,8 +15,7 @@ static constexpr auto gNativeScreenHeight = 200;
 static constexpr float gTileSize = 64000.;
 static constexpr auto gCellSize = 1600;
 static constexpr auto gHalfCellSize = gCellSize / 2;
-static constexpr auto gRotationSearchAmount = 100.0f;
-static constexpr auto gRotationSearchDistance = 100.0f;
+static constexpr auto gRotationSearchDistance = 400.0f;
 
 static constexpr auto gCombatGridCellSize = 300;
 static constexpr auto gCombatGridRows = 13u;

--- a/bak/movement.cpp
+++ b/bak/movement.cpp
@@ -156,17 +156,28 @@ std::optional<GameHeading> SnapHeadingIfOvershot(
     GameHeading newHeading,
     GameHeading targetHeading)
 {
-    const auto forwardDist =
-        (newHeading - oldHeading + gBakHeadingFullCircle) % gBakHeadingFullCircle;
-
-    if (forwardDist == 0 || forwardDist >= gBakHeadingHalfCircle)
+    if (oldHeading == newHeading)
         return std::nullopt;
 
-    const auto distToTarget =
-        (targetHeading - oldHeading + gBakHeadingFullCircle) % gBakHeadingFullCircle;
+    const auto ccwDist =
+        (newHeading - oldHeading + gBakHeadingFullCircle) % gBakHeadingFullCircle;
+    const auto cwDist =
+        (oldHeading - newHeading + gBakHeadingFullCircle) % gBakHeadingFullCircle;
 
-    if (distToTarget > 0 && distToTarget <= forwardDist)
-        return targetHeading;
+    if (ccwDist <= cwDist)
+    {
+        const auto distToTarget =
+            (targetHeading - oldHeading + gBakHeadingFullCircle) % gBakHeadingFullCircle;
+        if (distToTarget > 0 && distToTarget <= ccwDist)
+            return targetHeading;
+    }
+    else
+    {
+        const auto distToTarget =
+            (oldHeading - targetHeading + gBakHeadingFullCircle) % gBakHeadingFullCircle;
+        if (distToTarget > 0 && distToTarget <= cwDist)
+            return targetHeading;
+    }
 
     return std::nullopt;
 }

--- a/game/movementManager.cpp
+++ b/game/movementManager.cpp
@@ -379,7 +379,8 @@ std::optional<BAK::GameHeading> MovementManager::GetOpenDirection(
         return GetOpenDirectionFollowRoad(playerLocation, distance);
     }
 
-    const auto currentHeading = playerLocation.mHeading;
+    const auto currentHeading = BAK::SnapHeading(
+        playerLocation.mHeading, BAK::gBakSmallRotationBakHeading);
 
     std::int16_t leftStep  = BAK::gBakSmallRotationBakHeading;
     leftStep = -leftStep;


### PR DESCRIPTION
This means that in tunnels we will not allow completely free movement since we are searching out a further distance to detect that movement is not allowed.