### PR TITLE
Issue #318 - When underground auto rotate

### DIFF
--- a/game/movementManager.cpp
+++ b/game/movementManager.cpp
@@ -613,6 +613,38 @@ void MovementManager::CommitPendingMove()
     SetFollowRoadButtonVisible(IsOnRoad(mCamera.GetGameLocation().mPosition));
 }
 
+void MovementManager::ApplyPendingTurn()
+{
+    const auto target = *mPendingTurnHeading;
+    const auto oldHeading = mCamera.GetHeading();
+
+    const auto delta = sAutoRotateSpeed * mCamera.GetDeltaTime();
+    auto angle = mCamera.GetAngle();
+
+    if (mPendingTurnDirection == BAK::CardinalDirection::West)
+    {
+        angle.x = BAK::NormaliseRadians(angle.x + delta);
+    }
+    else
+    {
+        angle.x = BAK::NormaliseRadians(angle.x - delta);
+    }
+    mCamera.SetAngle(angle);
+
+    const auto newHeading = mCamera.GetHeading();
+    if (const auto snapped = BAK::SnapHeadingIfOvershot(oldHeading, newHeading, target))
+    {
+        auto snappedAngle = BAK::ToGlAngle(*snapped);
+        snappedAngle.y = mCamera.GetAngle().y;
+        mCamera.SetAngle(snappedAngle);
+    }
+
+    if (mCamera.GetHeading() == target)
+    {
+        mPendingTurnHeading.reset();
+    }
+}
+
 void MovementManager::MoveLeft()
 {
     if (mGameState.GetFollowRoad())
@@ -643,6 +675,11 @@ float MovementManager::GetDefaultHeight() const
 
 void MovementManager::MoveForward(bool strafe)
 {
+    if (mPendingTurnHeading)
+    {
+        return;
+    }
+
     if (!mGameState.GetFollowRoad())
     {
         if (strafe)
@@ -724,6 +761,13 @@ void MovementManager::MoveBackward(bool strafe)
 
 bool MovementManager::Update()
 {
+    if (mPendingTurnHeading)
+    {
+        mCamera.RejectPendingMove();
+        ApplyPendingTurn();
+        return true;
+    }
+
     if (!mCamera.HasPendingMove())
     {
         return false;
@@ -769,7 +813,16 @@ bool MovementManager::Update()
 
     if (openHeading)
     {
-        RotateTowardOpenHeading(*openHeading, gameLocation.mHeading);
+        if (mGameState.IsUnderground())
+        {
+            mPendingTurnHeading = *openHeading;
+            mPendingTurnDirection = BAK::GetRotationDirection(
+                gameLocation.mHeading, *openHeading);
+        }
+        else
+        {
+            RotateTowardOpenHeading(*openHeading, gameLocation.mHeading);
+        }
     }
     else
     {

--- a/game/movementManager.hpp
+++ b/game/movementManager.hpp
@@ -38,6 +38,8 @@ struct PitCross
 class MovementManager
 {
 public:
+    static constexpr float sAutoRotateSpeed = 6.0;
+
     MovementManager(
         Camera& camera,
         BAK::GameState& gameState,
@@ -56,6 +58,8 @@ public:
     void SetSpeedScale(float scale);
 
     bool Update();
+
+    void ApplyPendingTurn();
 
     bool CannotMoveHere(BAK::GamePosition playerPos) const;
     bool IsOnRoad(BAK::GamePosition playerPos) const;
@@ -97,6 +101,9 @@ private:
     float mDefaultHeight{BAK::gBakCameraHeight};
     bool mClipEnabled{false};
     bool mWallSlide{false};
+
+    std::optional<BAK::GameHeading> mPendingTurnHeading;
+    BAK::CardinalDirection mPendingTurnDirection{};
 
     const Logging::Logger& mLogger;
 };


### PR DESCRIPTION
Auto-rotate when encountering a barrier as BaK does in tunnels.

I don't want to auto-rotate above ground for now though.