### PR TITLE
Issue #318 - Simplify blocks/allows classification

### DIFF
--- a/bak/collision.cpp
+++ b/bak/collision.cpp
@@ -15,6 +15,23 @@
 
 namespace BAK {
 
+bool AllowsMovement(EntityType type)
+{
+    using enum EntityType;
+    switch (type)
+    {
+    case TERRAIN: [[fallthrough]];
+    case EXTERIOR: [[fallthrough]];
+    case BRIDGE: [[fallthrough]];
+    case TUNNEL1: [[fallthrough]];
+    case PIT: [[fallthrough]];
+    case DOOR:
+        return true;
+    default:
+        return false;
+    }
+}
+
 // Assumes the point is already in model clip space
 bool PointInClipElement(glm::vec2 point, const ClipElement& element)
 {
@@ -54,55 +71,15 @@ bool PointInModelClip(glm::vec2 point, const ModelClip& clip)
 
 bool BlocksMovement(const ZoneItem& item)
 {
-    const auto& clip = item.GetModelClip();
-    const bool hasClip = clip && !clip->mElements.empty();
-    const auto flags = item.GetEntityFlags();
-
-    if (!hasClip) return false;
-
-    if (flags == EF_TERRAIN)
-    {
-        switch (item.GetEntityType())
-        {
-        case EntityType::INTERIOR: return true;
-        default: return false;
-        }
-    }
-
-    if (item.GetEntityType() == EntityType::BRIDGE
-        || item.GetEntityType() == EntityType::PIT)
-    {
-        return false;
-    }
-
-    return true;
+    return !AllowsMovement(item);
 }
 
 bool AllowsMovement(const ZoneItem& item)
 {
     const auto& clip = item.GetModelClip();
     const bool hasClip = clip && !clip->mElements.empty();
-    const auto flags = item.GetEntityFlags();
-
     if (!hasClip) return false;
-
-    if (flags == EF_TERRAIN)
-    {
-        switch (item.GetEntityType())
-        {
-        case EntityType::EXTERIOR: return true;
-        default: break;
-        }
-    }
-
-    if (item.GetEntityType() == EntityType::BRIDGE
-        || item.GetEntityType() == EntityType::TUNNEL1
-        || item.GetEntityType() == EntityType::PIT)
-    {
-        return true;
-    }
-
-    return false;
+    return AllowsMovement(item.GetEntityType());
 }
 
 std::optional<float> ComputeHeight(

--- a/bak/collision.hpp
+++ b/bak/collision.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "bak/entityType.hpp"
+
 #include <glm/glm.hpp>
 
 #include <optional>
@@ -10,8 +12,11 @@ struct ClipElement;
 struct ModelClip;
 class ZoneItem;
 
+bool AllowsMovement(EntityType type);
+
 bool PointInClipElement(glm::vec2 point, const ClipElement& element);
 bool PointInModelClip(glm::vec2 point, const ModelClip&);
+
 bool BlocksMovement(const ZoneItem&);
 bool AllowsMovement(const ZoneItem&);
 


### PR DESCRIPTION
The original just uses explicit entity types rather than any complicated logic to determine whether GID objects block or allow movement. Use that instead of my hand rolled equivalent.